### PR TITLE
Update control panel UI and implement subjects CRUD

### DIFF
--- a/frontend/src/components/Entities/Subject/SubjectList.jsx
+++ b/frontend/src/components/Entities/Subject/SubjectList.jsx
@@ -1,4 +1,124 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import adminClient from '../../../api/adminClient.js';
+import { setSubjects } from './subjectSlice.js';
+
 export default function SubjectList() {
-  return <div>Subject list placeholder</div>;
+  const dispatch = useDispatch();
+  const subjects = useSelector(state => state.subjects.items);
+  const list = Array.isArray(subjects) ? subjects : [];
+  const [name, setName] = useState('');
+  const [schoolId, setSchoolId] = useState('');
+  const [editId, setEditId] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [editSchoolId, setEditSchoolId] = useState('');
+
+  useEffect(() => {
+    adminClient
+      .get('/subjects')
+      .then(res => dispatch(setSubjects(res.data)))
+      .catch(() => {});
+  }, [dispatch]);
+
+  const addSubject = () => {
+    adminClient
+      .post('/subjects', { name, school_id: Number(schoolId) })
+      .then(res => {
+        dispatch(setSubjects([...list, res.data]));
+        setName('');
+        setSchoolId('');
+      })
+      .catch(() => {});
+  };
+
+  const startEdit = subj => {
+    setEditId(subj.id);
+    setEditName(subj.name);
+    setEditSchoolId(subj.school_id);
+  };
+
+  const saveEdit = () => {
+    adminClient
+      .put(`/subjects/${editId}`, {
+        name: editName,
+        school_id: Number(editSchoolId),
+      })
+      .then(res => {
+        dispatch(setSubjects(list.map(s => (s.id === editId ? res.data : s))));
+        setEditId(null);
+      })
+      .catch(() => {});
+  };
+
+  const remove = id => {
+    adminClient.delete(`/subjects/${id}`).then(() => {
+      dispatch(setSubjects(list.filter(s => s.id !== id)));
+    });
+  };
+
+  return (
+    <div>
+      <h1>Предметы</h1>
+      <div>
+        <input
+          placeholder="Название"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          placeholder="ID школы"
+          value={schoolId}
+          onChange={e => setSchoolId(e.target.value)}
+        />
+        <button onClick={addSubject}>Добавить</button>
+      </div>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Название</th>
+            <th>Школа</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map(s => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>
+                {editId === s.id ? (
+                  <input
+                    value={editName}
+                    onChange={e => setEditName(e.target.value)}
+                  />
+                ) : (
+                  s.name
+                )}
+              </td>
+              <td>
+                {editId === s.id ? (
+                  <input
+                    value={editSchoolId}
+                    onChange={e => setEditSchoolId(e.target.value)}
+                  />
+                ) : (
+                  s.school_id
+                )}
+              </td>
+              <td>
+                {editId === s.id ? (
+                  <button onClick={saveEdit}>Сохранить</button>
+                ) : (
+                  <>
+                    <button onClick={() => startEdit(s)}>Ред.</button>
+                    <button onClick={() => remove(s.id)}>X</button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/components/Layout/Header.jsx
+++ b/frontend/src/components/Layout/Header.jsx
@@ -6,7 +6,7 @@ const menu = [
   { to: '/', label: 'Главная' },
   { to: '/journal', label: 'Журнал' },
   { to: '/planning', label: 'Планирование' },
-  { to: '/admin', label: 'Справочники' },
+  { to: '/admin', label: 'Панель управления' },
   { to: '/reports', label: 'Отчёты' },
 ];
 

--- a/frontend/src/components/Layout/Sidebar.jsx
+++ b/frontend/src/components/Layout/Sidebar.jsx
@@ -3,10 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { FiMenu } from 'react-icons/fi';
 
 const links = [
-  { to: '#a', label: 'Сущность A' },
-  { to: '#b', label: 'Сущность B' },
-  { to: '#c', label: 'Сущность C' },
-  { to: '#d', label: 'Сущность D' },
+  { to: 'subjects', label: 'Предметы' },
 ];
 
 export default function Sidebar() {
@@ -16,7 +13,6 @@ export default function Sidebar() {
       <button className="toggle" onClick={() => setOpen(!open)}>
         <FiMenu />
       </button>
-      <h2>НазваниеРаздела</h2>
       <ul>
         {links.map(link => (
           <li key={link.label}>

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -6,7 +6,6 @@ export default function DashboardPage() {
 
   return (
     <div>
-      <h1>Название страницы</h1>
       <div className="tabs">
         <button
           className={tab === 'data' ? 'active' : ''}

--- a/frontend/src/routes/AdminRoutes.jsx
+++ b/frontend/src/routes/AdminRoutes.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import DashboardPage from '../pages/DashboardPage.jsx';
-import CityList from '../components/Entities/City/CityList.jsx';
-import SchoolList from '../components/Entities/School/SchoolList.jsx';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import SubjectList from '../components/Entities/Subject/SubjectList.jsx';
 import NotFound from '../pages/NotFound.jsx';
 
 export default function AdminRoutes() {
   return (
     <Routes>
-      <Route index element={<DashboardPage />} />
-      <Route path="cities" element={<CityList />} />
-      <Route path="schools" element={<SchoolList />} />
+      <Route index element={<Navigate to="subjects" replace />} />
+      <Route path="subjects" element={<SubjectList />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/frontend/src/store/rootReducer.js
+++ b/frontend/src/store/rootReducer.js
@@ -1,11 +1,13 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import cityReducer from '../components/Entities/City/citySlice.js';
 import schoolReducer from '../components/Entities/School/schoolSlice.js';
+import subjectReducer from '../components/Entities/Subject/subjectSlice.js';
 // other reducers can be added here
 import notificationReducer from './toastSlice.js';
 
 export default combineReducers({
   cities: cityReducer,
   schools: schoolReducer,
+  subjects: subjectReducer,
   notifications: notificationReducer,
 });

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -48,10 +48,6 @@ body {
 }
 
 .sidebar {
-  position: fixed;
-  top: 60px;
-  bottom: 0;
-  left: 0;
   width: 220px;
   background: #F7F8FA;
   border-right: 1px solid #E1E4EB;
@@ -90,7 +86,11 @@ body {
 }
 .admin-container {
   margin-top: 60px;
-  margin-left: 220px;
+  display: flex;
+}
+
+.admin-content {
+  flex: 1;
   padding: 32px;
 }
 
@@ -99,7 +99,7 @@ body {
     display: none;
   }
   .admin-container {
-    margin-left: 0;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- rename menu item to **Панель управления**
- rework sidebar and admin container layout
- highlight subjects as first entity in sidebar
- route `/admin` to the subjects page
- implement basic CRUD operations for subjects
- wire subjects reducer into Redux store
- handle case where subjects list may be undefined

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68412eea0fd0833384a775d07944bd7a