### PR TITLE
Fix admin subject API URL

### DIFF
--- a/frontend/src/api/adminClient.js
+++ b/frontend/src/api/adminClient.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+// Use the backend API running on port 8000. Requests go directly to the
+// FastAPI server rather than the Parcel dev server to avoid 405 errors.
 const adminClient = axios.create({
-  baseURL: '/api/admin',
+  baseURL: 'http://localhost:8000',
 });
 
 adminClient.interceptors.response.use(


### PR DESCRIPTION
## Summary
- correct admin API URL so requests go to backend

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fd9293a7883338aea1a1f4f84e279