### PR TITLE
Add teacher management routes and sidebar link

### DIFF
--- a/frontend/src/components/Layout/Sidebar.jsx
+++ b/frontend/src/components/Layout/Sidebar.jsx
@@ -4,6 +4,7 @@ import { FiMenu } from 'react-icons/fi';
 
 const links = [
   { to: 'subjects', label: 'Предметы' },
+  { to: 'teachers', label: 'Преподаватели' },
 ];
 
 export default function Sidebar() {

--- a/frontend/src/routes/AdminRoutes.jsx
+++ b/frontend/src/routes/AdminRoutes.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import SubjectList from '../components/Entities/Subject/SubjectList.jsx';
+import TeacherList from '../components/Entities/Teacher/TeacherList.jsx';
 import NotFound from '../pages/NotFound.jsx';
 
 export default function AdminRoutes() {
@@ -8,6 +9,7 @@ export default function AdminRoutes() {
     <Routes>
       <Route index element={<Navigate to="subjects" replace />} />
       <Route path="subjects" element={<SubjectList />} />
+      <Route path="teachers" element={<TeacherList />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/frontend/src/store/rootReducer.js
+++ b/frontend/src/store/rootReducer.js
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import cityReducer from '../components/Entities/City/citySlice.js';
 import schoolReducer from '../components/Entities/School/schoolSlice.js';
 import subjectReducer from '../components/Entities/Subject/subjectSlice.js';
+import teacherReducer from '../components/Entities/Teacher/teacherSlice.js';
 // other reducers can be added here
 import notificationReducer from './toastSlice.js';
 
@@ -9,5 +10,6 @@ export default combineReducers({
   cities: cityReducer,
   schools: schoolReducer,
   subjects: subjectReducer,
+  teachers: teacherReducer,
   notifications: notificationReducer,
 });


### PR DESCRIPTION
## Summary
- register teachers slice in the redux root reducer
- add sidebar link for teachers
- define `teachers` route in admin panel

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850ee8859e08333a8b0130ea2c55781