### PR TITLE
Introduce MUI based UI with theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,20 @@
 
 ```bash
 cd frontend
-npm install
+npm i
 ```
 
 2. Запустите дев‑сервер:
 
 ```bash
-npm run start
+npm run dev
 ```
 
 Приложение будет доступно на `http://localhost:3000`.
+
+**Переменные окружения**
+
+- `VITE_API_URL` – адрес backend (пример: `http://localhost:8000`).
 
 Проект использует Redux Toolkit и разделён по сущностям в папке `src/components`. Общая маршрутизация админки находится в `src/routes/AdminRoutes.jsx`.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,19 +3,28 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@hookform/resolvers": "^3.1.1",
+    "@mui/icons-material": "^5.15.8",
+    "@mui/material": "^5.15.8",
     "@reduxjs/toolkit": "^1.9.7",
     "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.1",
     "react-icons": "^4.11.0",
     "react-redux": "^8.1.2",
-    "react-router-dom": "^6.16.0"
+    "react-router-dom": "^6.16.0",
+    "yup": "^1.2.0"
   },
   "scripts": {
     "start": "parcel public/index.html --port 3000",
-    "build": "parcel build public/index.html"
+    "build": "parcel build public/index.html",
+    "dev": "parcel public/index.html --port 3000"
   },
   "devDependencies": {
+    "buffer": "^6.0.3",
     "parcel": "^2.15.2"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,26 @@
-import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
-import Header from './components/Layout/Header.jsx';
-import LoginPage from './pages/LoginPage.jsx';
-import AdminDashboard from './pages/AdminDashboard.jsx';
-import NotFound from './pages/NotFound.jsx';
+import React, { Suspense, lazy } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { CircularProgress } from '@mui/material';
+import PageLayout from './components/Layout/PageLayout.jsx';
 import './styles/globals.css';
+
+const LoginPage = lazy(() => import('./pages/LoginPage.jsx'));
+const AdminDashboard = lazy(() => import('./pages/AdminDashboard.jsx'));
+const NotFound = lazy(() => import('./pages/NotFound.jsx'));
 
 export default function App() {
   return (
-    <>
-      <Header />
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/admin/*" element={<AdminDashboard />} />
-        <Route path="/" element={<div>Home</div>} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </>
+    <BrowserRouter>
+      <PageLayout>
+        <Suspense fallback={<CircularProgress />}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/admin/*" element={<AdminDashboard />} />
+            <Route path="/" element={<div>Home</div>} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
+      </PageLayout>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/components/Layout/PageLayout.jsx
+++ b/frontend/src/components/Layout/PageLayout.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { AppBar, Toolbar, Container, Box, Typography } from '@mui/material';
+
+export default function PageLayout({ children }) {
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            ЭЖ
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Container component="main" sx={{ my: 4 }}>
+        {children}
+      </Container>
+      <Box component="footer" sx={{ p: 2, textAlign: 'center', bgcolor: 'background.default' }}>
+        <Typography variant="body2">© 2024</Typography>
+      </Box>
+    </>
+  );
+}

--- a/frontend/src/components/UI/Button.jsx
+++ b/frontend/src/components/UI/Button.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Button as MuiButton } from '@mui/material';
 
-export default function Button({ children, ...props }) {
-  return (
-    <button className="btn" {...props}>
-      {children}
-    </button>
-  );
+export default function Button({ variant = 'primary', ...props }) {
+  const color =
+    variant === 'secondary' ? 'secondary' : variant === 'text' ? 'inherit' : 'primary';
+  const muiVariant = variant === 'text' ? 'text' : 'contained';
+
+  return <MuiButton color={color} variant={muiVariant} {...props} />;
 }

--- a/frontend/src/components/UI/Notifier.jsx
+++ b/frontend/src/components/UI/Notifier.jsx
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+import { Snackbar, Alert } from '@mui/material';
+
+export default function Notifier() {
+  const [message, setMessage] = useState(null);
+  const handleClose = () => setMessage(null);
+
+  return (
+    <Snackbar open={Boolean(message)} autoHideDuration={4000} onClose={handleClose}>
+      <Alert severity="success" onClose={handleClose} sx={{ width: '100%' }}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
 import App from './App.jsx';
 import store from './store/store.js';
+import theme from './theme.js';
 
 const root = createRoot(document.getElementById('root'));
 root.render(
   <Provider store={store}>
-    <BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
       <App />
-    </BrowserRouter>
+    </ThemeProvider>
   </Provider>
 );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,42 +1,56 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import './login.css';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { TextField, Box, Typography } from '@mui/material';
+import Button from '../components/UI/Button.jsx';
+
+const schema = yup.object({
+  username: yup.string().required('Обязательное поле'),
+  password: yup.string().required('Обязательное поле')
+});
 
 export default function LoginPage() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm({ resolver: yupResolver(schema) });
 
-  const handleSubmit = e => {
-    e.preventDefault();
+  const onSubmit = () => {
     // TODO: authenticate via API
     navigate('/');
   };
 
   return (
-    <div className="login-page">
-      <form className="login-form" onSubmit={handleSubmit}>
-        <h2>Вход</h2>
-        <label>
-          Имя пользователя
-          <input
-            type="text"
-            value={username}
-            onChange={e => setUsername(e.target.value)}
-            required
-          />
-        </label>
-        <label>
-          Пароль
-          <input
-            type="password"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            required
-          />
-        </label>
-        <button type="submit">Войти</button>
-      </form>
-    </div>
+    <Box sx={{ maxWidth: 360, mx: 'auto', mt: 8 }}>
+      <Typography variant="h5" component="h1" align="center" gutterBottom>
+        Вход
+      </Typography>
+      <Box component="form" onSubmit={handleSubmit(onSubmit)} noValidate>
+        <TextField
+          label="Имя пользователя"
+          fullWidth
+          margin="normal"
+          {...register('username')}
+          error={Boolean(errors.username)}
+          helperText={errors.username?.message}
+        />
+        <TextField
+          label="Пароль"
+          type="password"
+          fullWidth
+          margin="normal"
+          {...register('password')}
+          error={Boolean(errors.password)}
+          helperText={errors.password?.message}
+        />
+        <Button type="submit" fullWidth sx={{ mt: 2 }}>
+          Войти
+        </Button>
+      </Box>
+    </Box>
   );
 }

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,0 +1,36 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#3B82F6' },
+    secondary: { main: '#22C55E' },
+    error: { main: '#EF4444' },
+    background: { default: '#F7F7F7' },
+    text: { primary: '#111827' }
+  },
+  typography: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 14,
+    h6: { fontSize: 20, fontWeight: 600 },
+    h5: { fontSize: 24, fontWeight: 700 }
+  },
+  shape: { borderRadius: 8 },
+  shadows: [
+    'none',
+    '0px 4px 10px rgba(0,0,0,0.08)',
+    ...Array(23).fill('none')
+  ],
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          boxShadow: 'none'
+        }
+      }
+    }
+  }
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- add Material UI, hook-form and yup to frontend dependencies
- implement design tokens in `theme.js`
- replace old Button with MUI version
- add `PageLayout` and `Notifier` components
- rewrite login page with react-hook-form and MUI inputs
- update router to use lazy loading and `PageLayout`
- wrap app in MUI `ThemeProvider`
- update README with new start instructions

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68511ff1fcf88333b14c43373f9c6412