### PR TITLE
Update admin layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Header from './components/Layout/Header.jsx';
+import Footer from './components/Layout/Footer.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import AdminDashboard from './pages/AdminDashboard.jsx';
 import NotFound from './pages/NotFound.jsx';
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="/" element={<div>Home</div>} />
         <Route path="*" element={<NotFound />} />
       </Routes>
+      <Footer />
     </>
   );
 }

--- a/frontend/src/components/Layout/Footer.jsx
+++ b/frontend/src/components/Layout/Footer.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+
+export default function Footer() {
+  return (
+    <Box component="footer" className="app-footer">
+      <span>© 2024 Gradebook</span>
+    </Box>
+  );
+}

--- a/frontend/src/components/Layout/Sidebar.jsx
+++ b/frontend/src/components/Layout/Sidebar.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 
 const links = [
@@ -28,7 +28,7 @@ export default function Sidebar() {
   }
 
   return (
-    <Drawer variant="permanent" open>
+    <Paper className="sidebar" elevation={0}>
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
         <IconButton onClick={() => setOpen(false)} size="large">
           <MenuRoundedIcon />
@@ -43,6 +43,6 @@ export default function Sidebar() {
           </ListItem>
         ))}
       </List>
-    </Drawer>
+    </Paper>
   );
 }

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -5,12 +5,14 @@ import Notifications from '../components/Layout/Notifications.jsx';
 
 export default function AdminDashboard() {
   return (
-    <div className="admin-container">
-      <Sidebar />
-      <div className="admin-content">
-        <AdminRoutes />
+    <div className="admin-wrapper">
+      <div className="admin-sidebar">
+        <Sidebar />
       </div>
-      <Notifications />
+      <div className="admin-content-scroll">
+        <AdminRoutes />
+        <Notifications />
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -178,3 +178,9 @@ body {
   background: #0D2F7F;
   color: #fff;
 }
+
+.admin-wrapper { max-width: 1200px; margin: 60px auto; display: flex; }
+.admin-sidebar { position: sticky; top: 80px; align-self: flex-start; margin-right: 16px; }
+.admin-content-scroll { flex: 1; overflow-y: auto; max-height: calc(100vh - 120px); padding: 32px; }
+.app-footer { background: #0D2F7F; color: #fff; text-align: center; padding: 16px; margin-top: auto; }
+


### PR DESCRIPTION
## Summary
- add footer component
- refactor admin layout to keep sidebar fixed and content scrollable
- center dashboard layout and add footer
- adjust sidebar to use Paper instead of Drawer

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853993ec1f08333acede68bd7cb9a30