### PR TITLE
UI tweaks and add dialogs

### DIFF
--- a/frontend/src/components/Entities/Subject/SubjectList.jsx
+++ b/frontend/src/components/Entities/Subject/SubjectList.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import adminClient from '../../../api/adminClient.js';
 import { setSubjects } from './subjectSlice.js';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
 
 export default function SubjectList() {
   const dispatch = useDispatch();
@@ -9,6 +15,7 @@ export default function SubjectList() {
   const list = Array.isArray(subjects) ? subjects : [];
   const [name, setName] = useState('');
   const [schoolId, setSchoolId] = useState('');
+  const [addOpen, setAddOpen] = useState(false);
   const [editId, setEditId] = useState(null);
   const [editName, setEditName] = useState('');
   const [editSchoolId, setEditSchoolId] = useState('');
@@ -27,6 +34,7 @@ export default function SubjectList() {
         dispatch(setSubjects([...list, res.data]));
         setName('');
         setSchoolId('');
+        setAddOpen(false);
       })
       .catch(() => {});
   };
@@ -59,19 +67,26 @@ export default function SubjectList() {
   return (
     <div>
       <h1>Предметы</h1>
-      <div>
-        <input
-          placeholder="Название"
-          value={name}
-          onChange={e => setName(e.target.value)}
-        />
-        <input
-          placeholder="ID школы"
-          value={schoolId}
-          onChange={e => setSchoolId(e.target.value)}
-        />
-        <button onClick={addSubject}>Добавить</button>
-      </div>
+      <Button variant="contained" className="add-btn" onClick={() => setAddOpen(true)}>
+        Добавить
+      </Button>
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)}>
+        <DialogTitle>Новый предмет</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Название" value={name} onChange={e => setName(e.target.value)} />
+          <TextField
+            label="ID школы"
+            value={schoolId}
+            onChange={e => setSchoolId(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddOpen(false)}>Отмена</Button>
+          <Button onClick={addSubject} variant="contained">
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Dialog>
       <table className="data-table">
         <thead>
           <tr>

--- a/frontend/src/components/Entities/Teacher/TeacherList.jsx
+++ b/frontend/src/components/Entities/Teacher/TeacherList.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import adminClient from '../../../api/adminClient.js';
 import { setTeachers } from './teacherSlice.js';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
 
 export default function TeacherList() {
   const dispatch = useDispatch();
@@ -12,6 +18,7 @@ export default function TeacherList() {
   const [lastName, setLastName] = useState('');
   const [contactInfo, setContactInfo] = useState('');
   const [schoolId, setSchoolId] = useState('');
+  const [addOpen, setAddOpen] = useState(false);
 
   const [editId, setEditId] = useState(null);
   const [editFirstName, setEditFirstName] = useState('');
@@ -40,6 +47,7 @@ export default function TeacherList() {
         setLastName('');
         setContactInfo('');
         setSchoolId('');
+        setAddOpen(false);
       })
       .catch(() => {});
   };
@@ -76,29 +84,24 @@ export default function TeacherList() {
   return (
     <div>
       <h1>Преподаватели</h1>
-      <div>
-        <input
-          placeholder="Имя"
-          value={firstName}
-          onChange={e => setFirstName(e.target.value)}
-        />
-        <input
-          placeholder="Фамилия"
-          value={lastName}
-          onChange={e => setLastName(e.target.value)}
-        />
-        <input
-          placeholder="Контакт"
-          value={contactInfo}
-          onChange={e => setContactInfo(e.target.value)}
-        />
-        <input
-          placeholder="ID школы"
-          value={schoolId}
-          onChange={e => setSchoolId(e.target.value)}
-        />
-        <button onClick={addTeacher}>Добавить</button>
-      </div>
+      <Button variant="contained" className="add-btn" onClick={() => setAddOpen(true)}>
+        Добавить
+      </Button>
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)}>
+        <DialogTitle>Новый преподаватель</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Имя" value={firstName} onChange={e => setFirstName(e.target.value)} />
+          <TextField label="Фамилия" value={lastName} onChange={e => setLastName(e.target.value)} />
+          <TextField label="Контакт" value={contactInfo} onChange={e => setContactInfo(e.target.value)} />
+          <TextField label="ID школы" value={schoolId} onChange={e => setSchoolId(e.target.value)} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddOpen(false)}>Отмена</Button>
+          <Button onClick={addTeacher} variant="contained">
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Dialog>
       <table className="data-table">
         <thead>
           <tr>

--- a/frontend/src/components/Layout/Header.jsx
+++ b/frontend/src/components/Layout/Header.jsx
@@ -5,6 +5,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded';
 
@@ -19,27 +20,36 @@ const menu = [
 export default function Header() {
   return (
     <AppBar position="fixed">
-      <Toolbar>
-        <MenuBookRoundedIcon sx={{ mr: 2 }} />
-        <Box sx={{ flexGrow: 1, display: 'flex', gap: 2 }}>
-          {menu.map(item => (
-            <Button
-              key={item.to}
-              component={NavLink}
-              to={item.to}
-              color="inherit"
-              sx={{ textTransform: 'none' }}
-            >
-              {item.label}
+      <Toolbar disableGutters>
+        <Container
+          maxWidth="lg"
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <MenuBookRoundedIcon />
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              {menu.map(item => (
+                <Button
+                  key={item.to}
+                  component={NavLink}
+                  to={item.to}
+                  color="inherit"
+                  sx={{ textTransform: 'none' }}
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </Box>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Button component={NavLink} to="/help" color="inherit" sx={{ textTransform: 'none' }}>
+              Справка
             </Button>
-          ))}
-        </Box>
-        <Button component={NavLink} to="/help" color="inherit" sx={{ textTransform: 'none' }}>
-          Справка
-        </Button>
-        <IconButton color="inherit">
-          <AccountCircleRoundedIcon />
-        </IconButton>
+            <IconButton color="inherit">
+              <AccountCircleRoundedIcon />
+            </IconButton>
+          </Box>
+        </Container>
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -112,9 +112,13 @@ body {
   background: #fff;
   box-shadow: inset 0 -1px 0 #E1E4EB;
 }
-.data-table th, .data-table td {
+.data-table th,
+.data-table td {
   padding: 8px;
   border-bottom: 1px solid #E1E4EB;
+}
+.data-table th {
+  text-align: left;
 }
 .data-table tbody tr:nth-child(even) {
   background: #FAFBFD;


### PR DESCRIPTION
## Summary
- center header elements with a container
- left-align table headers
- use dialog forms to add subjects and teachers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68539d38bbc48333a9b210c931c6fb04