### PR TITLE
Unify teacher name field

### DIFF
--- a/backend/alembic/versions/597cb480e371_teacher_full_name.py
+++ b/backend/alembic/versions/597cb480e371_teacher_full_name.py
@@ -1,0 +1,27 @@
+"""merge teacher first+last into full_name
+
+Revision ID: 597cb480e371
+Revises: b4a1cc4fcb24
+Create Date: 2025-07-12 00:00:01
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '597cb480e371'
+down_revision: Union[str, None] = 'b4a1cc4fcb24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('teachers', sa.Column('full_name', sa.String(length=50), nullable=False))
+    op.drop_column('teachers', 'first_name')
+    op.drop_column('teachers', 'last_name')
+
+
+def downgrade() -> None:
+    op.add_column('teachers', sa.Column('first_name', sa.String(length=50), nullable=False))
+    op.add_column('teachers', sa.Column('last_name', sa.String(length=50), nullable=False))
+    op.drop_column('teachers', 'full_name')

--- a/backend/models/teacher.py
+++ b/backend/models/teacher.py
@@ -7,8 +7,7 @@ class Teacher(Base):
     __tablename__ = 'teachers'
 
     id = Column(Integer, primary_key=True, index=True)
-    first_name = Column(String(50), nullable=False)
-    last_name = Column(String(50), nullable=False)
+    full_name = Column(String(50), nullable=False)
     contact_info = Column(String(100), nullable=True)
     school_id = Column(Integer, ForeignKey('schools.id', ondelete='CASCADE'), nullable=False)
 

--- a/backend/schemas/teacher.py
+++ b/backend/schemas/teacher.py
@@ -3,8 +3,7 @@ from pydantic import BaseModel
 from typing import Optional
 
 class TeacherBase(BaseModel):
-    first_name: str
-    last_name: str
+    full_name: str
     contact_info: Optional[str] = None
     school_id: int  # Новое поле
 


### PR DESCRIPTION
## Summary
- consolidate `first_name` and `last_name` into `full_name` for Teacher
- adjust Pydantic schema accordingly
- add Alembic migration for the change

## Testing
- `python -m py_compile backend/models/teacher.py backend/schemas/teacher.py backend/alembic/versions/597cb480e371_teacher_full_name.py`

------
https://chatgpt.com/codex/tasks/task_e_685a387d4738833391d23b1ebdb2ef6c