### PR TITLE
Add class teacher role

### DIFF
--- a/backend/alembic/versions/f7cc120ae15a_add_role_to_class_teacher.py
+++ b/backend/alembic/versions/f7cc120ae15a_add_role_to_class_teacher.py
@@ -1,0 +1,28 @@
+"""add role to class teacher
+
+Revision ID: f7cc120ae15a
+Revises: 597cb480e371
+Create Date: 2025-06-24 06:03:51.879332
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f7cc120ae15a'
+down_revision: Union[str, None] = '597cb480e371'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('class_teachers', sa.Column('role', sa.Enum('homeroom', 'assistant', name='classteacherrole'), nullable=False, server_default='assistant'))
+    op.alter_column('class_teachers', 'role', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('class_teachers', 'role')
+    op.execute('DROP TYPE IF EXISTS classteacherrole')

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from routers.parent_router import router as parent_router
 from routers.grade_router import router as grade_router
 from routers.schedule_router import router as schedule_router
 from routers.class_router import router as class_router
+from routers.class_teacher_router import router as class_teacher_router
 from routers.attendance_router import router as attendance_router
 from routers.administrator_router import router as administrator_router
 from routers.region_router import router as region_router
@@ -47,6 +48,7 @@ app.include_router(parent_router)
 app.include_router(grade_router)
 app.include_router(schedule_router)
 app.include_router(class_router)
+app.include_router(class_teacher_router)
 app.include_router(attendance_router)
 app.include_router(administrator_router)
 app.include_router(region_router)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,5 +12,5 @@ from .grade import Grade
 from .parent import Parent
 from .subject import Subject
 from .teacher_subject import TeacherSubject
-from .class_ import Class, class_subjects, class_teachers
+from .class_ import Class, class_subjects, ClassTeacher, ClassTeacherRole
 from .user import User, RoleEnum

--- a/backend/models/class_.py
+++ b/backend/models/class_.py
@@ -1,5 +1,6 @@
 # backend/models/class_.py
-from sqlalchemy import Column, Integer, String, ForeignKey, Table
+import enum
+from sqlalchemy import Column, Integer, String, ForeignKey, Table, Enum
 from sqlalchemy.orm import relationship
 
 from core.db import Base
@@ -12,13 +13,20 @@ class_subjects = Table(
     Column('subject_id', Integer, ForeignKey('subjects.id', ondelete='CASCADE'), primary_key=True)
 )
 
-# Association table between classes and teachers
-class_teachers = Table(
-    'class_teachers',
-    Base.metadata,
-    Column('class_id', Integer, ForeignKey('classes.id', ondelete='CASCADE'), primary_key=True),
-    Column('teacher_id', Integer, ForeignKey('teachers.id', ondelete='CASCADE'), primary_key=True)
-)
+class ClassTeacherRole(str, enum.Enum):
+    homeroom = "homeroom"
+    assistant = "assistant"
+
+
+class ClassTeacher(Base):
+    __tablename__ = 'class_teachers'
+
+    class_id = Column(Integer, ForeignKey('classes.id', ondelete='CASCADE'), primary_key=True)
+    teacher_id = Column(Integer, ForeignKey('teachers.id', ondelete='CASCADE'), primary_key=True)
+    role = Column(Enum(ClassTeacherRole), nullable=False)
+
+    school_class = relationship('Class', back_populates='class_teachers')
+    teacher = relationship('Teacher', back_populates='class_teachers')
 
 
 class Class(Base):
@@ -32,4 +40,12 @@ class Class(Base):
     school = relationship('School', back_populates='classes')
     students = relationship('Student', back_populates='school_class', cascade='all, delete-orphan')
     subjects = relationship('Subject', secondary=class_subjects, back_populates='classes')
-    teachers = relationship('Teacher', secondary=class_teachers, back_populates='classes')
+    teachers = relationship('Teacher', secondary='class_teachers', back_populates='classes')
+    class_teachers = relationship('ClassTeacher', back_populates='school_class', cascade='all, delete-orphan')
+    homeroom_teachers = relationship(
+        'Teacher',
+        secondary='class_teachers',
+        primaryjoin="and_(Class.id==ClassTeacher.class_id, ClassTeacher.role=='homeroom')",
+        secondaryjoin="Teacher.id==ClassTeacher.teacher_id",
+        viewonly=True,
+    )

--- a/backend/models/teacher.py
+++ b/backend/models/teacher.py
@@ -22,3 +22,11 @@ class Teacher(Base):
         cascade='all, delete-orphan'
     )
     classes = relationship('Class', secondary='class_teachers', back_populates='teachers')
+    class_teachers = relationship('ClassTeacher', back_populates='teacher', cascade='all, delete-orphan')
+    homeroom_classes = relationship(
+        'Class',
+        secondary='class_teachers',
+        primaryjoin="and_(Teacher.id==ClassTeacher.teacher_id, ClassTeacher.role=='homeroom')",
+        secondaryjoin="Class.id==ClassTeacher.class_id",
+        viewonly=True,
+    )

--- a/backend/repositories/class_teacher_repository.py
+++ b/backend/repositories/class_teacher_repository.py
@@ -1,0 +1,30 @@
+# backend/repositories/class_teacher_repository.py
+from sqlalchemy.orm import Session
+from models.class_ import ClassTeacher
+from schemas.class_teacher import ClassTeacherCreate
+
+
+class ClassTeacherRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get(self, class_id: int, teacher_id: int) -> ClassTeacher:
+        return self.db.query(ClassTeacher).filter(
+            ClassTeacher.class_id == class_id,
+            ClassTeacher.teacher_id == teacher_id,
+        ).first()
+
+    def get_all(self, skip: int = 0, limit: int = 100):
+        return self.db.query(ClassTeacher).offset(skip).limit(limit).all()
+
+    def create(self, ct: ClassTeacherCreate) -> ClassTeacher:
+        db_ct = ClassTeacher(**ct.dict())
+        self.db.add(db_ct)
+        self.db.commit()
+        return db_ct
+
+    def delete(self, class_id: int, teacher_id: int) -> None:
+        db_ct = self.get(class_id, teacher_id)
+        if db_ct:
+            self.db.delete(db_ct)
+            self.db.commit()

--- a/backend/routers/class_teacher_router.py
+++ b/backend/routers/class_teacher_router.py
@@ -1,0 +1,21 @@
+# backend/routers/class_teacher_router.py
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from core.db import get_db
+from schemas.class_teacher import ClassTeacherCreate, ClassTeacherRead
+from repositories.class_teacher_repository import ClassTeacherRepository
+
+router = APIRouter(prefix="/class-teachers", tags=["class_teachers"])
+
+
+@router.post("/", response_model=ClassTeacherRead)
+def assign_class_teacher(ct: ClassTeacherCreate, db: Session = Depends(get_db)):
+    repo = ClassTeacherRepository(db)
+    return repo.create(ct)
+
+
+@router.delete("/{class_id}/{teacher_id}")
+def remove_class_teacher(class_id: int, teacher_id: int, db: Session = Depends(get_db)):
+    repo = ClassTeacherRepository(db)
+    repo.delete(class_id, teacher_id)
+    return {"ok": True}

--- a/backend/schemas/class_teacher.py
+++ b/backend/schemas/class_teacher.py
@@ -1,0 +1,18 @@
+# backend/schemas/class_teacher.py
+from pydantic import BaseModel
+from models.class_ import ClassTeacherRole
+
+
+class ClassTeacherBase(BaseModel):
+    class_id: int
+    teacher_id: int
+    role: ClassTeacherRole
+
+
+class ClassTeacherCreate(ClassTeacherBase):
+    pass
+
+
+class ClassTeacherRead(ClassTeacherBase):
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- add `ClassTeacher` model with role field and view-only relations
- expose `ClassTeacherRole` enum via new schema
- implement `ClassTeacherRepository` and `class_teacher_router`
- register the new router
- provide alembic migration for the `role` column

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3ee4027c8333bae74d698da27896