### PR TITLE
Add regular role to class teachers

### DIFF
--- a/backend/models/class_.py
+++ b/backend/models/class_.py
@@ -14,6 +14,7 @@ class_subjects = Table(
 )
 
 class ClassTeacherRole(str, enum.Enum):
+    regular = "regular"
     homeroom = "homeroom"
     assistant = "assistant"
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -126,7 +126,7 @@ This document summarizes the SQLAlchemy models used in the backend.
   - `id` – primary key
   - `name` – unique
   - `school_id` – FK to `schools.id` (CASCADE)
-- **Relationships:** has many `students`, many-to-many with `Subject` via `class_subjects` and with `Teacher` via `class_teachers`. `class_teachers` records determine homeroom/assistant teachers.
+- **Relationships:** has many `students`, many-to-many with `Subject` via `class_subjects` and with `Teacher` via `class_teachers`. `class_teachers` records determine homeroom, assistant or regular teachers.
 
 ## ClassTeacher
 - **Table:** `class_teachers`
@@ -146,6 +146,6 @@ This document summarizes the SQLAlchemy models used in the backend.
 
 ### Enumerations
 - **RoleEnum:** defines user roles (`superuser`, `administrator`, `teacher`, `student`, `parent`).
-- **ClassTeacherRole:** roles for the `class_teachers` table (`homeroom`, `assistant`).
+- **ClassTeacherRole:** roles for the `class_teachers` table (`regular`, `homeroom`, `assistant`).
 
 Cascade behaviors are mainly used on foreign keys with `ondelete='CASCADE'` to automatically remove dependent records.


### PR DESCRIPTION
## Summary
- extend `ClassTeacherRole` enum with a `regular` value
- document the new role in the DB schema overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6a13a7bc8333a3779c63130be608