### PR TITLE
Add teachers import router to FastAPI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from routers.school_router import router as school_router
 from routers.academic_year_router import router as academic_year_router
 from routers.user_router import router as user_router
 from routers.auth_router import router as auth_router
+from app.import_teachers.router import router as import_teachers_router
 
 
 from fastapi.middleware.cors import CORSMiddleware 
@@ -57,6 +58,7 @@ app.include_router(school_router)
 app.include_router(academic_year_router)
 app.include_router(user_router)
 app.include_router(auth_router)
+app.include_router(import_teachers_router)
 
 # При необходимости создания таблиц без миграций
 # Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- register POST `/import/teachers` endpoint

## Testing
- `pytest -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685a718e356c8333999368e80d15b99e