### PR TITLE
Fix module path for uvicorn start

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,6 +1,6 @@
 # backend/core/config.py
 from pydantic_settings import BaseSettings
-from pydantic import Field, PostgresDsn
+from pydantic import Field
 
 
 class Settings(BaseSettings):
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     """
     Основные настройки приложения из переменных окружения
     """
-    DATABASE_URL: PostgresDsn = Field(..., env='DATABASE_URL')
+    DATABASE_URL: str = Field(..., env='DATABASE_URL')
     SECRET_KEY: str = Field(..., env='SECRET_KEY')
     ALGORITHM: str = 'HS256'
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,14 @@
 from fastapi import FastAPI
 from core.db import engine, Base
 
+# Ensure project root is in the import path when running from ``backend``
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
 # Импорт моделей для регистрации в metadata
 from models import student, teacher, subject, teacher_subject, parent, grade, schedule, attendance, administrator, user  # noqa
 


### PR DESCRIPTION
## Summary
- append project root to `sys.path` when running backend's `main.py`
- relax `DATABASE_URL` validation so app starts with simple URLs

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c389b04833385c107f37f0dd314