### PR TITLE
Fix duplicate table error

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from backend.models import (
+from models import (
     Class,
     ClassTeacher,
     ClassTeacherRole,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,5 @@
 # backend/main.py
 from fastapi import FastAPI
-from core.db import engine, Base
 
 # Ensure project root is in the import path when running from ``backend``
 import sys
@@ -9,6 +8,8 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
+
+from core.db import engine, Base
 
 # Импорт моделей для регистрации в metadata
 from models import student, teacher, subject, teacher_subject, parent, grade, schedule, attendance, administrator, user  # noqa

--- a/tests/test_teacher_import.py
+++ b/tests/test_teacher_import.py
@@ -22,8 +22,17 @@ from sqlalchemy.orm import sessionmaker
 
 from app.import_teachers.service import import_teachers_from_file
 from backend.core.db import Base
-from backend.models import (City, Class, ClassTeacher, ClassTeacherRole,
-                            Region, School, Subject, Teacher, TeacherSubject)
+from models import (
+    City,
+    Class,
+    ClassTeacher,
+    ClassTeacherRole,
+    Region,
+    School,
+    Subject,
+    Teacher,
+    TeacherSubject,
+)
 
 
 def run_migrations(url: str) -> None:


### PR DESCRIPTION
## Summary
- ensure backend root is added to path before database imports
- use consistent `models` import path

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685a801c55bc83338cb7d1d3c2f72ecc