### PR TITLE
Add full_name to schools

### DIFF
--- a/backend/alembic/versions/1e8d45aee0f1_add_full_name_to_school.py
+++ b/backend/alembic/versions/1e8d45aee0f1_add_full_name_to_school.py
@@ -1,0 +1,25 @@
+"""add full_name column to schools
+
+Revision ID: 1e8d45aee0f1
+Revises: aeedbaddcafe
+Create Date: 2025-08-31 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '1e8d45aee0f1'
+# previous revision
+down_revision: Union[str, None] = 'aeedbaddcafe'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('schools', sa.Column('full_name', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('schools', 'full_name')
+

--- a/backend/models/school.py
+++ b/backend/models/school.py
@@ -8,6 +8,7 @@ class School(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(150), nullable=False)
+    full_name = Column(String(255), nullable=True)
     city_id = Column(Integer, ForeignKey('cities.id', ondelete='CASCADE'), nullable=False)
 
     # Отношения

--- a/backend/schemas/school.py
+++ b/backend/schemas/school.py
@@ -1,10 +1,12 @@
 # backend/schemas/school.py
 from __future__ import annotations
 from pydantic import BaseModel
+from typing import Optional
 
 class SchoolBase(BaseModel):
     name: str
     city_id: int
+    full_name: Optional[str] = None
 
 class SchoolCreate(SchoolBase):
     pass


### PR DESCRIPTION
## Summary
- add optional `full_name` column for `School` model
- expose the new field in School schemas
- alembic migration for the new column

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb failed: cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685b952ec8888333b5ac30c1aad54388