### PR TITLE
Fix duplicate class_teacher entries

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -56,6 +56,9 @@ def _handle_row(
         homeroom_classes = _parse_list(row["Классный руководитель"])
         subject_name = str(row["Предмет"]).strip()
         regular_classes = _parse_list(row["Класс"])
+        # if a teacher is homeroom for a class, we don't create an additional
+        # regular association for the same class
+        regular_classes = [c for c in regular_classes if c not in homeroom_classes]
 
         teacher_cache = caches.setdefault("teachers", {})
         subject_cache = caches.setdefault("subjects", {})

--- a/backend/repositories/class_teacher_repository.py
+++ b/backend/repositories/class_teacher_repository.py
@@ -8,23 +8,39 @@ class ClassTeacherRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    def get(self, class_id: int, teacher_id: int) -> ClassTeacher:
-        return self.db.query(ClassTeacher).filter(
-            ClassTeacher.class_id == class_id,
-            ClassTeacher.teacher_id == teacher_id,
-        ).first()
+    def get(
+        self, class_id: int, teacher_id: int, academic_year_id: int
+    ) -> ClassTeacher:
+        """Retrieve a class-teacher relation for a specific academic year."""
+
+        return (
+            self.db.query(ClassTeacher)
+            .filter(
+                ClassTeacher.class_id == class_id,
+                ClassTeacher.teacher_id == teacher_id,
+                ClassTeacher.academic_year_id == academic_year_id,
+            )
+            .first()
+        )
 
     def get_all(self, skip: int = 0, limit: int = 100):
         return self.db.query(ClassTeacher).offset(skip).limit(limit).all()
 
     def create(self, ct: ClassTeacherCreate) -> ClassTeacher:
+        """Create a relation if it doesn't exist."""
+
+        db_ct = self.get(ct.class_id, ct.teacher_id, ct.academic_year_id)
+        if db_ct:
+            return db_ct
+
         db_ct = ClassTeacher(**ct.dict())
         self.db.add(db_ct)
         self.db.commit()
+        self.db.refresh(db_ct)
         return db_ct
 
-    def delete(self, class_id: int, teacher_id: int) -> None:
-        db_ct = self.get(class_id, teacher_id)
+    def delete(self, class_id: int, teacher_id: int, academic_year_id: int) -> None:
+        db_ct = self.get(class_id, teacher_id, academic_year_id)
         if db_ct:
             self.db.delete(db_ct)
             self.db.commit()


### PR DESCRIPTION
## Summary
- avoid creating both homeroom and regular entries for the same class/teacher
- make ClassTeacherRepository aware of academic_year_id to avoid duplicates

## Testing
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685bccc72dd8833382f7dcbb09e8a6fa