### PR TITLE
Fix teacher import forward fill

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -241,7 +241,9 @@ def import_teachers_from_file(
     if school is None:
         raise ValueError("school not found")
 
-    df = pd.read_excel(path, sheet_name="Справочник педагоги", header=2).ffill()
+    df = pd.read_excel(path, sheet_name="Справочник педагоги", header=2)
+    # only teacher names may span multiple rows, do not forward fill other columns
+    df["ФИО педагога"] = df["ФИО педагога"].ffill()
     report = ImportReport()
     caches: dict = {}
 


### PR DESCRIPTION
## Summary
- prevent ffill from copying homeroom values when importing teachers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685bd80347dc8333866a11757c39a10a