### PR TITLE
Separate class-teacher roles

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -15,6 +15,7 @@ from models import (
     Class,
     ClassTeacher,
     ClassTeacherRole,
+    ClassTeacherRoleAssociation,
     School,
     Subject,
     Teacher,
@@ -145,7 +146,7 @@ def _handle_row(
             key = (sc.id, teacher.id, academic_year_id, "regular")
             if key not in ct_cache:
                 exists = (
-                    db.query(ClassTeacher)
+                    db.query(ClassTeacherRoleAssociation)
                     .filter_by(
                         class_id=sc.id,
                         teacher_id=teacher.id,
@@ -155,8 +156,25 @@ def _handle_row(
                     .first()
                 )
                 if not exists:
+                    ct = (
+                        db.query(ClassTeacher)
+                        .filter_by(
+                            class_id=sc.id,
+                            teacher_id=teacher.id,
+                            academic_year_id=academic_year_id,
+                        )
+                        .first()
+                    )
+                    if ct is None:
+                        ct = ClassTeacher(
+                            class_id=sc.id,
+                            teacher_id=teacher.id,
+                            academic_year_id=academic_year_id,
+                        )
+                        db.add(ct)
+                        db.flush([ct])
                     db.add(
-                        ClassTeacher(
+                        ClassTeacherRoleAssociation(
                             class_id=sc.id,
                             teacher_id=teacher.id,
                             academic_year_id=academic_year_id,
@@ -172,7 +190,7 @@ def _handle_row(
             key = (sc.id, teacher.id, academic_year_id, "homeroom")
             if key not in ct_cache:
                 existing_homeroom = (
-                    db.query(ClassTeacher)
+                    db.query(ClassTeacherRoleAssociation)
                     .filter_by(
                         class_id=sc.id,
                         role=ClassTeacherRole.homeroom,
@@ -183,7 +201,7 @@ def _handle_row(
                 if existing_homeroom and existing_homeroom.teacher_id != teacher.id:
                     return [ImportError(row=int(row.name), error="homeroom conflict")]
                 exists = (
-                    db.query(ClassTeacher)
+                    db.query(ClassTeacherRoleAssociation)
                     .filter_by(
                         class_id=sc.id,
                         teacher_id=teacher.id,
@@ -193,8 +211,25 @@ def _handle_row(
                     .first()
                 )
                 if not exists:
+                    ct = (
+                        db.query(ClassTeacher)
+                        .filter_by(
+                            class_id=sc.id,
+                            teacher_id=teacher.id,
+                            academic_year_id=academic_year_id,
+                        )
+                        .first()
+                    )
+                    if ct is None:
+                        ct = ClassTeacher(
+                            class_id=sc.id,
+                            teacher_id=teacher.id,
+                            academic_year_id=academic_year_id,
+                        )
+                        db.add(ct)
+                        db.flush([ct])
                     db.add(
-                        ClassTeacher(
+                        ClassTeacherRoleAssociation(
                             class_id=sc.id,
                             teacher_id=teacher.id,
                             academic_year_id=academic_year_id,

--- a/backend/alembic/versions/abc123456789_split_class_teacher_roles.py
+++ b/backend/alembic/versions/abc123456789_split_class_teacher_roles.py
@@ -1,0 +1,77 @@
+"""split class teacher roles into separate table
+
+Revision ID: abc123456789
+Revises: 1e8d45aee0f1
+Create Date: 2025-09-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'abc123456789'
+down_revision: Union[str, None] = '1e8d45aee0f1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'class_teacher_roles',
+        sa.Column('class_id', sa.Integer(), nullable=False),
+        sa.Column('teacher_id', sa.Integer(), nullable=False),
+        sa.Column('academic_year_id', sa.Integer(), nullable=False),
+        sa.Column('role', sa.String(length=20), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['class_id', 'teacher_id', 'academic_year_id'],
+            ['class_teachers.class_id', 'class_teachers.teacher_id', 'class_teachers.academic_year_id'],
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('class_id', 'teacher_id', 'academic_year_id', 'role')
+    )
+
+    op.create_index(
+        'uq_one_homeroom_per_class',
+        'class_teacher_roles',
+        ['class_id', 'academic_year_id'],
+        unique=True,
+        postgresql_where=sa.text("role = 'homeroom'"),
+    )
+
+    op.execute(
+        "INSERT INTO class_teacher_roles(class_id, teacher_id, academic_year_id, role) "
+        "SELECT class_id, teacher_id, academic_year_id, role FROM class_teachers"
+    )
+
+    op.drop_index('uq_one_homeroom_per_class', table_name='class_teachers')
+    op.drop_constraint('chk_class_teacher_role', 'class_teachers', type_='check')
+    op.drop_column('class_teachers', 'role')
+
+
+def downgrade() -> None:
+    op.add_column(
+        'class_teachers',
+        sa.Column('role', sa.String(length=20), nullable=False, server_default='regular')
+    )
+    op.create_check_constraint(
+        'chk_class_teacher_role',
+        'class_teachers',
+        "role IN ('regular','homeroom','assistant')",
+    )
+    op.create_index(
+        'uq_one_homeroom_per_class',
+        'class_teachers',
+        ['class_id', 'academic_year_id'],
+        unique=True,
+        postgresql_where=sa.text("role = 'homeroom'"),
+    )
+
+    op.execute(
+        "INSERT INTO class_teachers(class_id, teacher_id, academic_year_id, role) "
+        "SELECT class_id, teacher_id, academic_year_id, role FROM class_teacher_roles"
+    )
+
+    op.drop_index('uq_one_homeroom_per_class', table_name='class_teacher_roles')
+    op.drop_table('class_teacher_roles')

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,5 +12,11 @@ from .grade import Grade
 from .parent import Parent
 from .subject import Subject
 from .teacher_subject import TeacherSubject
-from .class_ import Class, class_subjects, ClassTeacher, ClassTeacherRole
+from .class_ import (
+    Class,
+    class_subjects,
+    ClassTeacher,
+    ClassTeacherRole,
+    ClassTeacherRoleAssociation,
+)
 from .user import User, RoleEnum

--- a/backend/models/class_.py
+++ b/backend/models/class_.py
@@ -1,6 +1,17 @@
 # backend/models/class_.py
 import enum
-from sqlalchemy import Column, Integer, String, ForeignKey, Table, Enum, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    ForeignKey,
+    Table,
+    Enum,
+    UniqueConstraint,
+    ForeignKeyConstraint,
+    Index,
+    text,
+)
 from sqlalchemy.orm import relationship
 
 from core.db import Base
@@ -25,11 +36,43 @@ class ClassTeacher(Base):
     class_id = Column(Integer, ForeignKey('classes.id', ondelete='CASCADE'), primary_key=True)
     teacher_id = Column(Integer, ForeignKey('teachers.id', ondelete='CASCADE'), primary_key=True)
     academic_year_id = Column(Integer, ForeignKey('academic_years.id', ondelete='CASCADE'), primary_key=True)
-    role = Column(Enum(ClassTeacherRole), nullable=False)
 
     school_class = relationship('Class', back_populates='class_teachers')
     teacher = relationship('Teacher', back_populates='class_teachers')
     academic_year = relationship('AcademicYear', back_populates='class_teachers')
+    roles = relationship(
+        'ClassTeacherRoleAssociation',
+        back_populates='class_teacher',
+        cascade='all, delete-orphan',
+    )
+
+
+class ClassTeacherRoleAssociation(Base):
+    __tablename__ = 'class_teacher_roles'
+
+    class_id = Column(Integer, primary_key=True)
+    teacher_id = Column(Integer, primary_key=True)
+    academic_year_id = Column(Integer, primary_key=True)
+    role = Column(Enum(ClassTeacherRole), primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ['class_id', 'teacher_id', 'academic_year_id'],
+            ['class_teachers.class_id', 'class_teachers.teacher_id', 'class_teachers.academic_year_id'],
+            ondelete='CASCADE',
+        ),
+    )
+
+    class_teacher = relationship('ClassTeacher', back_populates='roles')
+
+# Unique index ensuring only one homeroom teacher per class and year
+Index(
+    'uq_one_homeroom_per_class',
+    ClassTeacherRoleAssociation.class_id,
+    ClassTeacherRoleAssociation.academic_year_id,
+    unique=True,
+    postgresql_where=text("role = 'homeroom'"),
+)
 
 
 class Class(Base):
@@ -53,8 +96,8 @@ class Class(Base):
     class_teachers = relationship('ClassTeacher', back_populates='school_class', cascade='all, delete-orphan')
     homeroom_teachers = relationship(
         'Teacher',
-        secondary='class_teachers',
-        primaryjoin="and_(Class.id==ClassTeacher.class_id, ClassTeacher.role=='homeroom')",
-        secondaryjoin="Teacher.id==ClassTeacher.teacher_id",
+        secondary='class_teacher_roles',
+        primaryjoin="and_(Class.id==ClassTeacherRoleAssociation.class_id, ClassTeacherRoleAssociation.role=='homeroom')",
+        secondaryjoin="Teacher.id==ClassTeacherRoleAssociation.teacher_id",
         viewonly=True,
     )

--- a/backend/models/teacher.py
+++ b/backend/models/teacher.py
@@ -1,6 +1,7 @@
 # backend/models/teacher.py
 from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
+from .class_ import ClassTeacherRoleAssociation
 from core.db import Base
 
 class Teacher(Base):
@@ -25,8 +26,8 @@ class Teacher(Base):
     class_teachers = relationship('ClassTeacher', back_populates='teacher', cascade='all, delete-orphan')
     homeroom_classes = relationship(
         'Class',
-        secondary='class_teachers',
-        primaryjoin="and_(Teacher.id==ClassTeacher.teacher_id, ClassTeacher.role=='homeroom')",
-        secondaryjoin="Class.id==ClassTeacher.class_id",
+        secondary='class_teacher_roles',
+        primaryjoin="and_(Teacher.id==ClassTeacherRoleAssociation.teacher_id, ClassTeacherRoleAssociation.role=='homeroom')",
+        secondaryjoin="Class.id==ClassTeacherRoleAssociation.class_id",
         viewonly=True,
     )

--- a/backend/schemas/class_teacher.py
+++ b/backend/schemas/class_teacher.py
@@ -6,6 +6,7 @@ from models.class_ import ClassTeacherRole
 class ClassTeacherBase(BaseModel):
     class_id: int
     teacher_id: int
+    academic_year_id: int
     role: ClassTeacherRole
 
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -133,8 +133,17 @@ This document summarizes the SQLAlchemy models used in the backend.
 - **Columns:**
   - `class_id` – PK & FK to `classes.id` (CASCADE)
   - `teacher_id` – PK & FK to `teachers.id` (CASCADE)
+  - `academic_year_id` – PK & FK to `academic_years.id` (CASCADE)
+- **Purpose:** base relation between teacher and class for a year.
+
+## ClassTeacherRoleAssociation
+- **Table:** `class_teacher_roles`
+- **Columns:**
+  - `class_id` – FK to `class_teachers.class_id`
+  - `teacher_id` – FK to `class_teachers.teacher_id`
+  - `academic_year_id` – FK to `class_teachers.academic_year_id`
   - `role` – Enum `ClassTeacherRole`
-- **Purpose:** maps teachers to classes with a role (e.g. homeroom).
+- **Purpose:** stores roles for class-teacher relation. Unique index ensures one homeroom teacher per class and academic year.
 
 ## Users
 - **Table:** `users`
@@ -146,6 +155,6 @@ This document summarizes the SQLAlchemy models used in the backend.
 
 ### Enumerations
 - **RoleEnum:** defines user roles (`superuser`, `administrator`, `teacher`, `student`, `parent`).
-- **ClassTeacherRole:** roles for the `class_teachers` table (`regular`, `homeroom`, `assistant`).
+- **ClassTeacherRole:** roles for class-teacher relations (`regular`, `homeroom`, `assistant`).
 
 Cascade behaviors are mainly used on foreign keys with `ondelete='CASCADE'` to automatically remove dependent records.

--- a/tests/test_teacher_import.py
+++ b/tests/test_teacher_import.py
@@ -27,6 +27,7 @@ from models import (
     Class,
     ClassTeacher,
     ClassTeacherRole,
+    ClassTeacherRoleAssociation,
     Region,
     School,
     Subject,
@@ -106,7 +107,7 @@ def test_import_happy_path(tmp_path):
 
         teachers = session.query(Teacher).all()
         assert len(teachers) == 2
-        assert session.query(ClassTeacher).filter_by(role=ClassTeacherRole.homeroom).count() == 1
+        assert session.query(ClassTeacherRoleAssociation).filter_by(role=ClassTeacherRole.homeroom).count() == 1
         assert session.query(AcademicYear).filter_by(name='2024/2025').count() == 1
         session.close()
 


### PR DESCRIPTION
## Summary
- store class teacher roles in dedicated table
- update models, repository and import service
- add Alembic migration for new table
- adjust tests and docs for the new structure

## Testing
- `pytest tests/test_teacher_import.py::test_import_happy_path -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685bda0b428c833382195e1566107039