### PR TITLE
Implement truncate flag for teacher import

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -284,25 +284,28 @@ def import_teachers_from_file(
     report = ImportReport()
     caches: dict = {}
 
-    class_ids = [
-        cid for (cid,) in db.query(Class.id).filter_by(
-            school_id=school.id,
-            academic_year_id=academic_year.id,
-        ).all()
-    ]
-    if class_ids:
-        db.query(ClassTeacher).filter(
-            ClassTeacher.class_id.in_(class_ids),
-            ClassTeacher.academic_year_id == academic_year.id,
-        ).delete(synchronize_session=False)
+    if truncate_associations:
+        class_ids = [
+            cid
+            for (cid,) in db.query(Class.id).filter_by(
+                school_id=school.id,
+                academic_year_id=academic_year.id,
+            ).all()
+        ]
+        if class_ids:
+            db.query(ClassTeacher).filter(
+                ClassTeacher.class_id.in_(class_ids),
+                ClassTeacher.academic_year_id == academic_year.id,
+            ).delete(synchronize_session=False)
 
-    teacher_ids = [tid for (tid,) in db.query(
-        Teacher.id).filter_by(school_id=school.id).all()]
-    if teacher_ids:
-        db.query(TeacherSubject).filter(
-            TeacherSubject.teacher_id.in_(teacher_ids),
-            TeacherSubject.academic_year_id == academic_year.id,
-        ).delete(synchronize_session=False)
+        teacher_ids = [
+            tid for (tid,) in db.query(Teacher.id).filter_by(school_id=school.id).all()
+        ]
+        if teacher_ids:
+            db.query(TeacherSubject).filter(
+                TeacherSubject.teacher_id.in_(teacher_ids),
+                TeacherSubject.academic_year_id == academic_year.id,
+            ).delete(synchronize_session=False)
 
     for start in range(0, len(df), 500):
         chunk = df.iloc[start: start + 500]


### PR DESCRIPTION
## Summary
- respect `truncate_associations` flag in importer
- check associations remain on re-import
- add test verifying behavior with truncate flag

## Testing
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685cef41963c8333a095a6f052243fb5