### PR TITLE
Add removal logic for teacher import

### DIFF
--- a/backend/alembic/versions/c1a349a48b2c_add_active_and_archived.py
+++ b/backend/alembic/versions/c1a349a48b2c_add_active_and_archived.py
@@ -1,0 +1,24 @@
+"""add active flag to teacher and archived flag to class
+
+Revision ID: c1a349a48b2c
+Revises: aeedbaddcafe
+Create Date: 2025-07-30 12:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'c1a349a48b2c'
+down_revision: Union[str, None] = 'aeedbaddcafe'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('teachers', sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'))
+    op.add_column('classes', sa.Column('is_archived', sa.Boolean(), nullable=False, server_default='false'))
+
+
+def downgrade() -> None:
+    op.drop_column('classes', 'is_archived')
+    op.drop_column('teachers', 'is_active')

--- a/backend/models/class_.py
+++ b/backend/models/class_.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     text,
+    Boolean,
 )
 from sqlalchemy.orm import relationship
 
@@ -82,6 +83,7 @@ class Class(Base):
     name = Column(String(10), nullable=False)
     school_id = Column(Integer, ForeignKey('schools.id', ondelete='CASCADE'), nullable=False)
     academic_year_id = Column(Integer, ForeignKey('academic_years.id', ondelete='CASCADE'), nullable=False)
+    is_archived = Column(Boolean, nullable=False, server_default='false')
 
     __table_args__ = (
         UniqueConstraint('name', 'school_id', 'academic_year_id'),

--- a/backend/models/teacher.py
+++ b/backend/models/teacher.py
@@ -1,5 +1,5 @@
 # backend/models/teacher.py
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
 from sqlalchemy.orm import relationship
 from .class_ import ClassTeacherRoleAssociation
 from core.db import Base
@@ -11,6 +11,7 @@ class Teacher(Base):
     full_name = Column(String(50), nullable=False)
     contact_info = Column(String(100), nullable=True)
     school_id = Column(Integer, ForeignKey('schools.id', ondelete='CASCADE'), nullable=False)
+    is_active = Column(Boolean, nullable=False, server_default='true')
 
     # Отношения
     subjects = relationship('Subject', secondary='teacher_subjects', back_populates='teachers')


### PR DESCRIPTION
## Summary
- extend ImportReport with deletion counters
- add `is_active` to Teacher and `is_archived` to Class
- implement cleanup of missing teachers, subjects and classes
- cover removal logic with new tests
- provide Alembic migration for new columns

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685cf6673c50833390568bbdf36f3276