### PR TITLE
Implement homeroom conflict and reassignment

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -36,6 +36,7 @@ class ImportReport(BaseModel):
     teachers_deleted: int = 0
     ts_deleted: int = 0
     ct_deleted: int = 0
+    homeroom_reassigned: int = 0
 
 
 class ImportError(BaseModel):
@@ -64,8 +65,7 @@ def _handle_row(
         regular_classes = _parse_list(row["Класс"])
         # if a teacher is homeroom for a class, we don't create an additional
         # regular association for the same class
-        regular_classes = [
-            c for c in regular_classes if c not in homeroom_classes]
+        regular_classes = [c for c in regular_classes if c not in homeroom_classes]
 
         teacher_cache = caches.setdefault("teachers", {})
         subject_cache = caches.setdefault("subjects", {})
@@ -159,7 +159,8 @@ def import_teachers_from_file(
     truncate_associations: bool = False,
 ) -> ImportReport:
     header_df = pd.read_excel(
-        path, sheet_name="Справочник педагоги", nrows=2, header=None)
+        path, sheet_name="Справочник педагоги", nrows=2, header=None
+    )
     year_line = str(header_df.iloc[0, 0])
     school_name = str(header_df.iloc[1, 0]).strip()
     m = re.search(r"(\d{4})/(\d{4})", year_line)
@@ -197,10 +198,12 @@ def import_teachers_from_file(
     if truncate_associations:
         class_ids = [
             cid
-            for (cid,) in db.query(Class.id).filter_by(
+            for (cid,) in db.query(Class.id)
+            .filter_by(
                 school_id=school.id,
                 academic_year_id=academic_year.id,
-            ).all()
+            )
+            .all()
         ]
         if class_ids:
             db.query(ClassTeacher).filter(
@@ -218,7 +221,7 @@ def import_teachers_from_file(
             ).delete(synchronize_session=False)
 
     for start in range(0, len(df), 500):
-        chunk = df.iloc[start: start + 500]
+        chunk = df.iloc[start : start + 500]
         for _, row in chunk.iterrows():
             errors = _handle_row(
                 row,
@@ -231,6 +234,38 @@ def import_teachers_from_file(
             if errors:
                 db.rollback()
                 raise ValueError(errors[0].error)
+
+    # check existing homerooms and handle conflicts or reassignment
+    if not truncate_associations:
+        file_homerooms: dict[int, int] = caches.get("file_homerooms", {})
+        if file_homerooms:
+            existing_homerooms = {
+                c.class_id: c.teacher_id
+                for c in (
+                    db.query(ClassTeacherRoleAssociation)
+                    .join(Class)
+                    .filter(Class.school_id == school.id)
+                    .filter(
+                        ClassTeacherRoleAssociation.academic_year_id == academic_year.id
+                    )
+                    .filter(
+                        ClassTeacherRoleAssociation.role == ClassTeacherRole.homeroom
+                    )
+                    .all()
+                )
+            }
+            ct_new: dict[tuple[int, int], set[ClassTeacherRole]] = caches.get(
+                "ct_new", {}
+            )
+            for class_id, new_teacher_id in file_homerooms.items():
+                old_teacher_id = existing_homerooms.get(class_id)
+                if old_teacher_id is not None and old_teacher_id != new_teacher_id:
+                    old_roles = ct_new.get((class_id, old_teacher_id))
+                    if old_roles is None:
+                        db.rollback()
+                        raise ValueError("homeroom conflict")
+                    old_roles.discard(ClassTeacherRole.homeroom)
+                    report.homeroom_reassigned += 1
 
     # diff update of associations when not truncating
     if not truncate_associations:
@@ -264,7 +299,9 @@ def import_teachers_from_file(
             unmatched = list(old_list)
             for sub_id in subjects:
                 if sub_id in old_map:
-                    ts_seen.add((teacher_name_by_id[teacher_id], subject_name_by_id[sub_id]))
+                    ts_seen.add(
+                        (teacher_name_by_id[teacher_id], subject_name_by_id[sub_id])
+                    )
                     unmatched.remove(old_map[sub_id])
                 else:
                     if unmatched:
@@ -280,7 +317,9 @@ def import_teachers_from_file(
                             )
                         )
                         report.teacher_subjects_created += 1
-                    ts_seen.add((teacher_name_by_id[teacher_id], subject_name_by_id[sub_id]))
+                    ts_seen.add(
+                        (teacher_name_by_id[teacher_id], subject_name_by_id[sub_id])
+                    )
 
         caches["ts_seen"] = ts_seen
 
@@ -296,7 +335,10 @@ def import_teachers_from_file(
         existing_ct_by_pair: dict[tuple[int, int], dict] = {}
         for ct in existing_ct:
             role_map = {r.role: r for r in ct.roles}
-            existing_ct_by_pair[(ct.class_id, ct.teacher_id)] = {"ct": ct, "roles": role_map}
+            existing_ct_by_pair[(ct.class_id, ct.teacher_id)] = {
+                "ct": ct,
+                "roles": role_map,
+            }
 
         ct_seen: set[tuple[str, str]] = set()
 

--- a/tests/test_teacher_import.py
+++ b/tests/test_teacher_import.py
@@ -14,6 +14,7 @@ os.environ.setdefault("DB_USER", "user")
 os.environ.setdefault("DB_PASSWORD", "pass")
 
 import pandas as pd
+import pytest
 import testing.postgresql
 from alembic import command
 from alembic.config import Config
@@ -39,15 +40,15 @@ from models import (
 
 
 def run_migrations(url: str) -> None:
-    os.environ['DATABASE_URL'] = url
-    cfg = Config('alembic.ini')
-    command.upgrade(cfg, 'head')
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, "head")
 
 
 def prepare_school(session):
-    region = Region(name='R')
-    city = City(name='C', region=region)
-    school = School(name='S', full_name='Test School', city=city)
+    region = Region(name="R")
+    city = City(name="C", region=region)
+    school = School(name="S", full_name="Test School", city=city)
     session.add_all([region, city, school])
     session.commit()
     return school.id
@@ -57,45 +58,45 @@ def make_excel(path: Path) -> None:
     df = pd.DataFrame(
         [
             {
-                'ФИО педагога': 'Teacher One',
-                'Классный руководитель': '',
-                'Предмет': 'Literature',
-                'Класс': '10A, 5A',
+                "ФИО педагога": "Teacher One",
+                "Классный руководитель": "",
+                "Предмет": "Literature",
+                "Класс": "10A, 5A",
             },
             {
-                'ФИО педагога': None,
-                'Классный руководитель': '',
-                'Предмет': 'Language',
-                'Класс': '10A, 5A',
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Language",
+                "Класс": "10A, 5A",
             },
             {
-                'ФИО педагога': 'Teacher Two',
-                'Классный руководитель': '1G',
-                'Предмет': 'Math',
-                'Класс': '1G, 4B',
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "1G",
+                "Предмет": "Math",
+                "Класс": "1G, 4B",
             },
             {
-                'ФИО педагога': None,
-                'Классный руководитель': '',
-                'Предмет': 'Talks',
-                'Класс': '1G, 4B',
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Talks",
+                "Класс": "1G, 4B",
             },
         ]
     )
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
-        df.to_excel(writer, sheet_name='Справочник педагоги', index=False, startrow=2)
-        ws = writer.sheets['Справочник педагоги']
-        ws.cell(row=1, column=1, value='Педагоги 2024/2025')
-        ws.cell(row=2, column=1, value='Test School')
+        df.to_excel(writer, sheet_name="Справочник педагоги", index=False, startrow=2)
+        ws = writer.sheets["Справочник педагоги"]
+        ws.cell(row=1, column=1, value="Педагоги 2024/2025")
+        ws.cell(row=2, column=1, value="Test School")
 
 
 def make_excel_from_rows(path: Path, rows: list[dict[str, str]]) -> None:
     df = pd.DataFrame(rows)
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
-        df.to_excel(writer, sheet_name='Справочник педагоги', index=False, startrow=2)
-        ws = writer.sheets['Справочник педагоги']
-        ws.cell(row=1, column=1, value='Педагоги 2024/2025')
-        ws.cell(row=2, column=1, value='Test School')
+        df.to_excel(writer, sheet_name="Справочник педагоги", index=False, startrow=2)
+        ws = writer.sheets["Справочник педагоги"]
+        ws.cell(row=1, column=1, value="Педагоги 2024/2025")
+        ws.cell(row=2, column=1, value="Test School")
 
 
 def test_import_happy_path(tmp_path):
@@ -105,7 +106,7 @@ def test_import_happy_path(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
 
         report = import_teachers_from_file(str(file), session)
@@ -117,8 +118,13 @@ def test_import_happy_path(tmp_path):
 
         teachers = session.query(Teacher).all()
         assert len(teachers) == 2
-        assert session.query(ClassTeacherRoleAssociation).filter_by(role=ClassTeacherRole.homeroom).count() == 1
-        assert session.query(AcademicYear).filter_by(name='2024/2025').count() == 1
+        assert (
+            session.query(ClassTeacherRoleAssociation)
+            .filter_by(role=ClassTeacherRole.homeroom)
+            .count()
+            == 1
+        )
+        assert session.query(AcademicYear).filter_by(name="2024/2025").count() == 1
         session.close()
 
 
@@ -129,7 +135,7 @@ def test_reimport_no_duplicates(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
 
     import_teachers_from_file(str(file), session)
@@ -147,7 +153,7 @@ def test_truncate_reimport(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
 
         import_teachers_from_file(str(file), session)
@@ -165,7 +171,7 @@ def test_dry_run(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
 
         report = import_teachers_from_file(str(file), session, dry_run=True)
@@ -181,32 +187,34 @@ def test_homeroom_conflict(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
         df = pd.DataFrame(
             [
                 {
-                    'ФИО педагога': 'Another',
-                    'Классный руководитель': '1G',
-                    'Предмет': 'Other',
-                    'Класс': '1G',
+                    "ФИО педагога": "Another",
+                    "Классный руководитель": "1G",
+                    "Предмет": "Other",
+                    "Класс": "1G",
                 }
             ]
         )
-        file2 = tmp_path / 'conflict.xlsx'
+        file2 = tmp_path / "conflict.xlsx"
         with pd.ExcelWriter(file2, engine="openpyxl") as writer:
-            df.to_excel(writer, sheet_name='Справочник педагоги', index=False, startrow=2)
-            ws = writer.sheets['Справочник педагоги']
-            ws.cell(row=1, column=1, value='Педагоги 2024/2025')
-            ws.cell(row=2, column=1, value='Test School')
+            df.to_excel(
+                writer, sheet_name="Справочник педагоги", index=False, startrow=2
+            )
+            ws = writer.sheets["Справочник педагоги"]
+            ws.cell(row=1, column=1, value="Педагоги 2024/2025")
+            ws.cell(row=2, column=1, value="Test School")
         try:
             import_teachers_from_file(str(file2), session)
         except ValueError:
             pass
         else:
-            assert False, 'conflict not raised'
+            assert False, "conflict not raised"
         session.close()
 
 
@@ -221,32 +229,34 @@ def test_homeroom_conflict_same_file(tmp_path):
         df = pd.DataFrame(
             [
                 {
-                    'ФИО педагога': 'One',
-                    'Классный руководитель': '1G',
-                    'Предмет': 'Math',
-                    'Класс': '1G',
+                    "ФИО педагога": "One",
+                    "Классный руководитель": "1G",
+                    "Предмет": "Math",
+                    "Класс": "1G",
                 },
                 {
-                    'ФИО педагога': 'Two',
-                    'Классный руководитель': '1G',
-                    'Предмет': 'Other',
-                    'Класс': '1G',
+                    "ФИО педагога": "Two",
+                    "Классный руководитель": "1G",
+                    "Предмет": "Other",
+                    "Класс": "1G",
                 },
             ]
         )
-        file = tmp_path / 'conflict_same_file.xlsx'
+        file = tmp_path / "conflict_same_file.xlsx"
         with pd.ExcelWriter(file, engine="openpyxl") as writer:
-            df.to_excel(writer, sheet_name='Справочник педагоги', index=False, startrow=2)
-            ws = writer.sheets['Справочник педагоги']
-            ws.cell(row=1, column=1, value='Педагоги 2024/2025')
-            ws.cell(row=2, column=1, value='Test School')
+            df.to_excel(
+                writer, sheet_name="Справочник педагоги", index=False, startrow=2
+            )
+            ws = writer.sheets["Справочник педагоги"]
+            ws.cell(row=1, column=1, value="Педагоги 2024/2025")
+            ws.cell(row=2, column=1, value="Test School")
 
         try:
             import_teachers_from_file(str(file), session)
         except ValueError:
             pass
         else:
-            assert False, 'conflict not raised'
+            assert False, "conflict not raised"
         session.close()
 
 
@@ -257,29 +267,29 @@ def test_remove_teacher(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
         rows = [
             {
-                'ФИО педагога': 'Teacher Two',
-                'Классный руководитель': '1G',
-                'Предмет': 'Math',
-                'Класс': '1G, 4B',
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "1G",
+                "Предмет": "Math",
+                "Класс": "1G, 4B",
             },
             {
-                'ФИО педагога': None,
-                'Классный руководитель': '',
-                'Предмет': 'Talks',
-                'Класс': '1G, 4B',
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Talks",
+                "Класс": "1G, 4B",
             },
         ]
-        file2 = tmp_path / 'teachers2.xlsx'
+        file2 = tmp_path / "teachers2.xlsx"
         make_excel_from_rows(file2, rows)
         report = import_teachers_from_file(str(file2), session)
         assert report.teachers_deleted == 1
-        assert session.query(Teacher).filter_by(full_name='Teacher One').count() == 0
+        assert session.query(Teacher).filter_by(full_name="Teacher One").count() == 0
         session.close()
 
 
@@ -290,25 +300,25 @@ def test_remove_subject_from_teacher(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
         rows = [
             {
-                'ФИО педагога': 'Teacher One',
-                'Классный руководитель': '',
-                'Предмет': 'Literature',
-                'Класс': '10A',
+                "ФИО педагога": "Teacher One",
+                "Классный руководитель": "",
+                "Предмет": "Literature",
+                "Класс": "10A",
             },
             {
-                'ФИО педагога': 'Teacher Two',
-                'Классный руководитель': '1G',
-                'Предмет': 'Math',
-                'Класс': '1G',
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "1G",
+                "Предмет": "Math",
+                "Класс": "1G",
             },
         ]
-        file2 = tmp_path / 'teachers2.xlsx'
+        file2 = tmp_path / "teachers2.xlsx"
         make_excel_from_rows(file2, rows)
         report = import_teachers_from_file(str(file2), session)
         assert report.ts_deleted == 2
@@ -325,29 +335,31 @@ def test_remove_class_and_archive_when_linked(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         school_id = prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
-        cls_1g = session.query(Class).filter_by(name='1G').one()
-        student = Student(full_name='Kid', class_name='1G', school_class=cls_1g, school_id=school_id)
+        cls_1g = session.query(Class).filter_by(name="1G").one()
+        student = Student(
+            full_name="Kid", class_name="1G", school_class=cls_1g, school_id=school_id
+        )
         session.add(student)
         session.commit()
 
         rows = [
             {
-                'ФИО педагога': 'Teacher One',
-                'Классный руководитель': '',
-                'Предмет': 'Literature',
-                'Класс': '10A',
+                "ФИО педагога": "Teacher One",
+                "Классный руководитель": "",
+                "Предмет": "Literature",
+                "Класс": "10A",
             },
         ]
-        file2 = tmp_path / 'teachers2.xlsx'
+        file2 = tmp_path / "teachers2.xlsx"
         make_excel_from_rows(file2, rows)
         report = import_teachers_from_file(str(file2), session)
-        assert session.query(Class).filter_by(name='5A').count() == 0
-        archived = session.query(Class).filter_by(name='1G').one()
+        assert session.query(Class).filter_by(name="5A").count() == 0
+        archived = session.query(Class).filter_by(name="1G").one()
         assert archived.is_archived is True
-        assert session.query(Class).filter_by(name='4B').count() == 0
+        assert session.query(Class).filter_by(name="4B").count() == 0
         session.close()
 
 
@@ -358,19 +370,19 @@ def test_dry_run_removals(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
         rows = [
             {
-                'ФИО педагога': 'Teacher Two',
-                'Классный руководитель': '1G',
-                'Предмет': 'Math',
-                'Класс': '1G',
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "1G",
+                "Предмет": "Math",
+                "Класс": "1G",
             },
         ]
-        file2 = tmp_path / 'teachers2.xlsx'
+        file2 = tmp_path / "teachers2.xlsx"
         make_excel_from_rows(file2, rows)
         report = import_teachers_from_file(str(file2), session, dry_run=True)
         assert report.teachers_deleted == 1
@@ -385,7 +397,7 @@ def test_diff_update_noop(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
@@ -404,17 +416,26 @@ def test_diff_update_change_role(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
-        assoc = session.query(ClassTeacherRoleAssociation).filter_by(role=ClassTeacherRole.homeroom).one()
+        assoc = (
+            session.query(ClassTeacherRoleAssociation)
+            .filter_by(role=ClassTeacherRole.homeroom)
+            .one()
+        )
         assoc.role = ClassTeacherRole.assistant
         session.commit()
 
         report = import_teachers_from_file(str(file), session)
         assert report.classteachers_updated == 1
-        assert session.query(ClassTeacherRoleAssociation).filter_by(role=ClassTeacherRole.homeroom).count() == 1
+        assert (
+            session.query(ClassTeacherRoleAssociation)
+            .filter_by(role=ClassTeacherRole.homeroom)
+            .count()
+            == 1
+        )
         session.close()
 
 
@@ -425,37 +446,37 @@ def test_diff_update_change_subject(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
         rows = [
             {
-                'ФИО педагога': 'Teacher One',
-                'Классный руководитель': '',
-                'Предмет': 'History',
-                'Класс': '10A, 5A',
+                "ФИО педагога": "Teacher One",
+                "Классный руководитель": "",
+                "Предмет": "History",
+                "Класс": "10A, 5A",
             },
             {
-                'ФИО педагога': None,
-                'Классный руководитель': '',
-                'Предмет': 'Language',
-                'Класс': '10A, 5A',
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Language",
+                "Класс": "10A, 5A",
             },
             {
-                'ФИО педагога': 'Teacher Two',
-                'Классный руководитель': '1G',
-                'Предмет': 'Math',
-                'Класс': '1G, 4B',
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "1G",
+                "Предмет": "Math",
+                "Класс": "1G, 4B",
             },
             {
-                'ФИО педагога': None,
-                'Классный руководитель': '',
-                'Предмет': 'Talks',
-                'Класс': '1G, 4B',
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Talks",
+                "Класс": "1G, 4B",
             },
         ]
-        file2 = tmp_path / 'teachers2.xlsx'
+        file2 = tmp_path / "teachers2.xlsx"
         make_excel_from_rows(file2, rows)
         report = import_teachers_from_file(str(file2), session)
         assert report.teachersubjects_updated == 1
@@ -470,15 +491,92 @@ def test_truncate_flag_still_works(tmp_path):
         Session = sessionmaker(bind=engine)
         session = Session()
         prepare_school(session)
-        file = tmp_path / 'teachers.xlsx'
+        file = tmp_path / "teachers.xlsx"
         make_excel(file)
         import_teachers_from_file(str(file), session)
 
-        assoc = session.query(ClassTeacherRoleAssociation).filter_by(role=ClassTeacherRole.homeroom).one()
+        assoc = (
+            session.query(ClassTeacherRoleAssociation)
+            .filter_by(role=ClassTeacherRole.homeroom)
+            .one()
+        )
         assoc.role = ClassTeacherRole.assistant
         session.commit()
 
-        report = import_teachers_from_file(str(file), session, truncate_associations=True)
+        report = import_teachers_from_file(
+            str(file), session, truncate_associations=True
+        )
         assert report.teacher_subjects_created == 4
         session.close()
 
+
+def test_homeroom_conflict_error(tmp_path):
+    with testing.postgresql.Postgresql() as pg:
+        run_migrations(pg.url())
+        engine = create_engine(pg.url())
+        Session = sessionmaker(bind=engine)
+        session = Session()
+        prepare_school(session)
+        file = tmp_path / "teachers.xlsx"
+        make_excel(file)
+        import_teachers_from_file(str(file), session)
+
+        rows = [
+            {
+                "ФИО педагога": "New HR",
+                "Классный руководитель": "1G",
+                "Предмет": "Other",
+                "Класс": "1G",
+            }
+        ]
+        file2 = tmp_path / "conflict.xlsx"
+        make_excel_from_rows(file2, rows)
+
+        with pytest.raises(ValueError):
+            import_teachers_from_file(str(file2), session)
+        session.close()
+
+
+def test_homeroom_reassign_ok(tmp_path):
+    with testing.postgresql.Postgresql() as pg:
+        run_migrations(pg.url())
+        engine = create_engine(pg.url())
+        Session = sessionmaker(bind=engine)
+        session = Session()
+        prepare_school(session)
+        file = tmp_path / "teachers.xlsx"
+        make_excel(file)
+        import_teachers_from_file(str(file), session)
+
+        rows = [
+            {
+                "ФИО педагога": "Teacher Two",
+                "Классный руководитель": "",
+                "Предмет": "Math",
+                "Класс": "1G, 4B",
+            },
+            {
+                "ФИО педагога": None,
+                "Классный руководитель": "",
+                "Предмет": "Talks",
+                "Класс": "1G, 4B",
+            },
+            {
+                "ФИО педагога": "New HR",
+                "Классный руководитель": "1G",
+                "Предмет": "Biology",
+                "Класс": "1G",
+            },
+        ]
+        file2 = tmp_path / "reassign.xlsx"
+        make_excel_from_rows(file2, rows)
+        report = import_teachers_from_file(str(file2), session)
+        assert report.homeroom_reassigned == 1
+        hr = (
+            session.query(ClassTeacherRoleAssociation)
+            .filter_by(role=ClassTeacherRole.homeroom)
+            .one()
+        )
+        teacher = session.query(Teacher).filter_by(id=hr.teacher_id).one()
+        assert teacher.full_name == "New HR"
+        session.close()


### PR DESCRIPTION
## Summary
- add `homeroom_reassigned` field in import report
- detect existing homeroom conflicts when importing teachers
- automatically reassign homeroom role if old teacher present in file
- add tests for conflict error and successful reassignment

## Testing
- `pytest tests/test_teacher_import.py::test_homeroom_conflict_error -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685cfdca3c608333af349c0abe49f7c9