### PR TITLE
Implement CLI report counters

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -2,22 +2,48 @@
 import argparse
 from typing import Any
 
-from app.import_teachers.service import import_teachers_from_file
+from app.import_teachers.service import ImportReport, import_teachers_from_file
 from backend.core.db import SessionLocal
+
+
+def _print_report(report: ImportReport) -> None:
+    header = f"{'Entity':20}{'Create':>8}{'Update':>8}{'Delete':>8}"
+    print(header)
+    rows = [
+        ("Teachers", report.teachers_created, report.teachers_updated, report.teachers_deleted),
+        ("Subjects", report.subjects_created, report.subjects_updated, report.subjects_deleted),
+        ("Classes", report.classes_created, report.classes_updated, report.classes_deleted),
+        (
+            "Teacher subjects",
+            report.teacher_subjects_created,
+            report.teacher_subjects_updated,
+            report.teacher_subjects_deleted,
+        ),
+        (
+            "Class teachers",
+            report.class_teachers_created,
+            report.class_teachers_updated,
+            report.class_teachers_deleted,
+        ),
+    ]
+    for name, c, u, d in rows:
+        print(f"{name:20}{c:8}{u:8}{d:8}")
+    if report.homeroom_reassigned:
+        print(f"homeroom_reassigned: {report.homeroom_reassigned}")
 
 
 def main(argv: list[str] | None = None) -> Any:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="cmd")
 
-    imp = sub.add_parser("import-teachers")
+    imp = sub.add_parser("teachers-import")
     imp.add_argument("file")
     imp.add_argument("--dry-run", action="store_true")
     imp.add_argument("--truncate-associations", action="store_true")
 
     args = parser.parse_args(argv)
 
-    if args.cmd == "import-teachers":
+    if args.cmd == "teachers-import":
         db = SessionLocal()
         try:
             report = import_teachers_from_file(
@@ -26,7 +52,7 @@ def main(argv: list[str] | None = None) -> Any:
                 dry_run=args.dry_run,
                 truncate_associations=args.truncate_associations,
             )
-            print(report.model_dump())
+            _print_report(report)
         except Exception as exc:  # pylint: disable=broad-except
             print(f"Error: {exc}")
             return 1

--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -27,15 +27,25 @@ logger = structlog.get_logger(__name__)
 
 class ImportReport(BaseModel):
     teachers_created: int = 0
-    subjects_created: int = 0
-    classes_created: int = 0
-    teacher_subjects_created: int = 0
-    class_teachers_created: int = 0
-    teachersubjects_updated: int = 0
-    classteachers_updated: int = 0
+    teachers_updated: int = 0
     teachers_deleted: int = 0
-    ts_deleted: int = 0
-    ct_deleted: int = 0
+
+    subjects_created: int = 0
+    subjects_updated: int = 0
+    subjects_deleted: int = 0
+
+    classes_created: int = 0
+    classes_updated: int = 0
+    classes_deleted: int = 0
+
+    teacher_subjects_created: int = 0
+    teacher_subjects_updated: int = 0
+    teacher_subjects_deleted: int = 0
+
+    class_teachers_created: int = 0
+    class_teachers_updated: int = 0
+    class_teachers_deleted: int = 0
+
     homeroom_reassigned: int = 0
 
 
@@ -307,7 +317,7 @@ def import_teachers_from_file(
                     if unmatched:
                         ts_to_update = unmatched.pop(0)
                         ts_to_update.subject_id = sub_id
-                        report.teachersubjects_updated += 1
+                        report.teacher_subjects_updated += 1
                     else:
                         db.add(
                             TeacherSubject(
@@ -360,7 +370,7 @@ def import_teachers_from_file(
                     new_val = next(iter(new_roles))
                     if role_obj.role != new_val:
                         role_obj.role = new_val
-                        report.classteachers_updated += 1
+                        report.class_teachers_updated += 1
                 else:
                     for r in old_roles - new_roles:
                         db.delete(role_map[r])
@@ -373,7 +383,7 @@ def import_teachers_from_file(
                                 role=r,
                             )
                         )
-                    report.classteachers_updated += 1
+                    report.class_teachers_updated += 1
 
         # now add completely new pairs
         for pair, roles in ct_new.items():
@@ -418,7 +428,7 @@ def import_teachers_from_file(
     for ts in existing_ts:
         key = (ts.teacher.full_name, ts.subject.name)
         if key not in ts_seen:
-            report.ts_deleted += 1
+            report.teacher_subjects_deleted += 1
             if not dry_run:
                 db.delete(ts)
 
@@ -434,7 +444,7 @@ def import_teachers_from_file(
     for ct in existing_ct:
         pair = (ct.school_class.name, ct.teacher.full_name)
         if pair not in ct_seen:
-            report.ct_deleted += 1
+            report.class_teachers_deleted += 1
             if not dry_run:
                 db.delete(ct)
 
@@ -461,6 +471,7 @@ def import_teachers_from_file(
     )
     for cl in existing_classes:
         if cl.name not in classes_seen:
+            report.classes_deleted += 1
             if not dry_run and len(cl.students) == 0:
                 db.delete(cl)
             else:


### PR DESCRIPTION
## Summary
- extend `ImportReport` with update and delete counters
- track class deletions during teacher import
- display formatted table in teachers-import CLI command
- rename CLI command and update tests
- add CLI stdout test

## Testing
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685d014ab3e08333a0b9ed71aff7bda6