### PR TITLE
Fix ambiguous join for homeroom lookup

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -257,7 +257,8 @@ def import_teachers_from_file(
                 c.class_id: c.teacher_id
                 for c in (
                     db.query(ClassTeacherRoleAssociation)
-                    .join(Class)
+                    .join(ClassTeacherRoleAssociation.class_teacher)
+                    .join(ClassTeacher.school_class)
                     .filter(Class.school_id == school.id)
                     .filter(
                         ClassTeacherRoleAssociation.academic_year_id == academic_year.id


### PR DESCRIPTION
## Summary
- disambiguate join when finding existing homeroom teachers

## Testing
- `pytest -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685d06d6b56c8333ba9ee710f2f4698b