### PR TITLE
Fix teacher re-import error

### DIFF
--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -317,7 +317,12 @@ def import_teachers_from_file(
                     ts_seen.add(
                         (teacher_name_by_id[teacher_id], subject_name_by_id[sub_id])
                     )
-                    unmatched.remove(old_map[sub_id])
+                    try:
+                        unmatched.remove(old_map[sub_id])
+                    except ValueError:
+                        # old_map may contain an entry already popped from
+                        # unmatched when handling a previous subject
+                        pass
                 else:
                     if unmatched:
                         ts_to_update = unmatched.pop(0)


### PR DESCRIPTION
## Summary
- handle repeated subject updates safely while importing teachers

## Testing
- `pytest tests/test_teacher_import.py::test_reimport_no_duplicates -q` *(fails: initdb failed - cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685d0b05f6148333be06c562b90a2a5e