### PR TITLE
Add term and grade kind enums

### DIFF
--- a/backend/alembic/versions/1cf1420fbe73_add_term_and_grade_kind_enums.py
+++ b/backend/alembic/versions/1cf1420fbe73_add_term_and_grade_kind_enums.py
@@ -1,0 +1,64 @@
+"""add term and grade kind enums
+
+Revision ID: 1cf1420fbe73
+Revises: f7cc120ae15a
+Create Date: 2025-08-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1cf1420fbe73"
+down_revision: Union[str, None] = "f7cc120ae15a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    term_type_enum = sa.Enum(
+        "trimester", "quarter", "semester", "year", name="term_type_enum"
+    )
+    grade_kind_enum = sa.Enum(
+        "regular",
+        "avg",
+        "weighted_avg",
+        "period_final",
+        "year_final",
+        "exam",
+        "state_exam",
+        name="grade_kind_enum",
+    )
+    term_type_enum.create(op.get_bind(), checkfirst=True)
+    grade_kind_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column("grades", sa.Column("term_type", term_type_enum, nullable=False))
+    op.add_column("grades", sa.Column("term_index", sa.SmallInteger(), nullable=False))
+    op.add_column("grades", sa.Column("grade_kind", grade_kind_enum, nullable=False))
+    op.add_column("grades", sa.Column("lesson_event_id", sa.Integer(), nullable=True))
+    op.alter_column("grades", "value", type_=sa.Numeric(4, 2))
+    op.create_index(
+        "uq_grade_unique",
+        "grades",
+        [
+            "student_id",
+            "subject_id",
+            "term_type",
+            "term_index",
+            "grade_kind",
+            "lesson_event_id",
+        ],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_grade_unique", table_name="grades")
+    op.alter_column("grades", "value", type_=sa.Integer())
+    op.drop_column("grades", "lesson_event_id")
+    op.drop_column("grades", "grade_kind")
+    op.drop_column("grades", "term_index")
+    op.drop_column("grades", "term_type")
+    op.execute("DROP TYPE IF EXISTS grade_kind_enum")
+    op.execute("DROP TYPE IF EXISTS term_type_enum")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,22 +1,16 @@
-from .region import Region
-from .city import City
-from .school import School
 from .academic_year import AcademicYear
-from .student import Student 
-from .teacher import Teacher  
-from .schedule import Schedule  
-from .grade import Grade  
-from .attendance import Attendance  
 from .administrator import Administrator
-from .grade import Grade
+from .attendance import Attendance
+from .city import City
+from .class_ import (Class, ClassTeacher, ClassTeacherRole,
+                     ClassTeacherRoleAssociation, class_subjects)
+from .grade import Grade, GradeKindEnum, TermTypeEnum
 from .parent import Parent
+from .region import Region
+from .schedule import Schedule
+from .school import School
+from .student import Student
 from .subject import Subject
+from .teacher import Teacher
 from .teacher_subject import TeacherSubject
-from .class_ import (
-    Class,
-    class_subjects,
-    ClassTeacher,
-    ClassTeacherRole,
-    ClassTeacherRoleAssociation,
-)
-from .user import User, RoleEnum
+from .user import RoleEnum, User

--- a/backend/models/grade.py
+++ b/backend/models/grade.py
@@ -1,21 +1,74 @@
 # backend/models/grade.py
-from sqlalchemy import Column, Integer, Date, ForeignKey
-from sqlalchemy.orm import relationship
+import enum
+
 from core.db import Base
+from sqlalchemy import (Column, Date, Enum, ForeignKey, Index, Integer,
+                        Numeric, SmallInteger)
+from sqlalchemy.orm import relationship
+
+
+class TermTypeEnum(str, enum.Enum):
+    trimester = "trimester"
+    quarter = "quarter"
+    semester = "semester"
+    year = "year"
+
+
+class GradeKindEnum(str, enum.Enum):
+    regular = "regular"
+    avg = "avg"
+    weighted_avg = "weighted_avg"
+    period_final = "period_final"
+    year_final = "year_final"
+    exam = "exam"
+    state_exam = "state_exam"
+
 
 class Grade(Base):
-    __tablename__ = 'grades'
+    __tablename__ = "grades"
 
     id = Column(Integer, primary_key=True, index=True)
-    value = Column(Integer, nullable=False)
+    value = Column(Numeric(4, 2), nullable=False)
     date = Column(Date, nullable=False)
-    student_id = Column(Integer, ForeignKey('students.id', ondelete='CASCADE'), nullable=False)
-    teacher_id = Column(Integer, ForeignKey('teachers.id', ondelete='CASCADE'), nullable=False)
-    subject_id = Column(Integer, ForeignKey('subjects.id', ondelete='RESTRICT'), nullable=False)
-    academic_year_id = Column(Integer, ForeignKey('academic_years.id', ondelete='CASCADE'), nullable=False)
+    term_type = Column(Enum(TermTypeEnum), nullable=False)
+    term_index = Column(SmallInteger, nullable=False)
+    grade_kind = Column(Enum(GradeKindEnum), nullable=False)
+    lesson_event_id = Column(Integer, nullable=True)
+    student_id = Column(
+        Integer,
+        ForeignKey("students.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    teacher_id = Column(
+        Integer,
+        ForeignKey("teachers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    subject_id = Column(
+        Integer,
+        ForeignKey("subjects.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    academic_year_id = Column(
+        Integer,
+        ForeignKey("academic_years.id", ondelete="CASCADE"),
+        nullable=False,
+    )
 
     # Отношения
-    student = relationship('Student', back_populates='grades')
-    teacher = relationship('Teacher', back_populates='grades')
-    subject = relationship('Subject', back_populates='grades')
-    academic_year = relationship('AcademicYear', back_populates='grades')
+    student = relationship("Student", back_populates="grades")
+    teacher = relationship("Teacher", back_populates="grades")
+    subject = relationship("Subject", back_populates="grades")
+    academic_year = relationship("AcademicYear", back_populates="grades")
+
+
+Index(
+    "uq_grade_unique",
+    Grade.student_id,
+    Grade.subject_id,
+    Grade.term_type,
+    Grade.term_index,
+    Grade.grade_kind,
+    Grade.lesson_event_id,
+    unique=True,
+)

--- a/backend/schemas/grade.py
+++ b/backend/schemas/grade.py
@@ -1,16 +1,25 @@
 # backend/schemas/grade.py
-from pydantic import BaseModel
 from datetime import date
 
+from models.grade import GradeKindEnum, TermTypeEnum
+from pydantic import BaseModel
+
+
 class GradeBase(BaseModel):
-    value: int
+    value: float
     date: date
     student_id: int
     teacher_id: int
     subject_id: int
+    term_type: TermTypeEnum
+    term_index: int
+    grade_kind: GradeKindEnum
+    lesson_event_id: int | None = None
+
 
 class GradeCreate(GradeBase):
     pass
+
 
 class GradeRead(GradeBase):
     id: int


### PR DESCRIPTION
## Summary
- add enumerations for grade terms and kinds
- extend grade model with term info and new value type
- expose new enums from `backend.models`
- update grade schemas accordingly
- create Alembic migration for new fields and unique index

## Testing
- `pytest -q` *(fails: RuntimeError: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e3bca3d8c8333942c4fd59aec55b0