### PR TITLE
Add extended attendance status

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_extended_attendance_status.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_extended_attendance_status.py
@@ -1,0 +1,45 @@
+"""extended attendance status
+
+Revision ID: a1b2c3d4e5f6
+Revises: 810c85aedd55
+Create Date: 2025-07-01 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '810c85aedd55'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    status_enum = sa.Enum(
+        'present',
+        'absent',
+        'sick',
+        'late',
+        'excused',
+        name='attendance_status_enum',
+    )
+    status_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column('attendance', sa.Column('status', status_enum, nullable=True))
+    op.add_column('attendance', sa.Column('minutes_late', sa.SmallInteger(), nullable=True))
+    op.add_column('attendance', sa.Column('comment', sa.Text(), nullable=True))
+    op.execute("UPDATE attendance SET status='present' WHERE is_present = TRUE")
+    op.execute("UPDATE attendance SET status='absent' WHERE is_present = FALSE")
+    op.alter_column('attendance', 'status', nullable=False)
+    op.drop_column('attendance', 'is_present')
+
+
+def downgrade() -> None:
+    op.add_column('attendance', sa.Column('is_present', sa.Boolean(), nullable=True))
+    op.execute("UPDATE attendance SET is_present = (status='present')")
+    op.alter_column('attendance', 'is_present', nullable=False)
+    op.drop_column('attendance', 'comment')
+    op.drop_column('attendance', 'minutes_late')
+    op.drop_column('attendance', 'status')
+    op.execute('DROP TYPE IF EXISTS attendance_status_enum')
+

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,6 +1,6 @@
 from .academic_year import AcademicYear
 from .administrator import Administrator
-from .attendance import Attendance
+from .attendance import Attendance, AttendanceStatusEnum
 from .city import City
 from .class_ import (Class, ClassTeacher, ClassTeacherRole,
                      ClassTeacherRoleAssociation, class_subjects)

--- a/backend/models/attendance.py
+++ b/backend/models/attendance.py
@@ -1,14 +1,41 @@
 # backend/models/attendance.py
-from sqlalchemy import Column, Integer, Date, Boolean, ForeignKey
+import enum
+from sqlalchemy import (
+    Column,
+    Integer,
+    Date,
+    Enum,
+    ForeignKey,
+    SmallInteger,
+    Text,
+)
 from sqlalchemy.orm import relationship
 from core.db import Base
+
+
+class AttendanceStatusEnum(str, enum.Enum):
+    present = "present"
+    absent = "absent"
+    sick = "sick"
+    late = "late"
+    excused = "excused"
+
+
+STATUS_CHAR_MAP = {
+    "Н": AttendanceStatusEnum.absent,
+    "Б": AttendanceStatusEnum.sick,
+    "О": AttendanceStatusEnum.late,
+    "У": AttendanceStatusEnum.excused,
+}
 
 class Attendance(Base):
     __tablename__ = 'attendance'
 
     id = Column(Integer, primary_key=True, index=True)
     date = Column(Date, nullable=False)
-    is_present = Column(Boolean, nullable=False)
+    status = Column(Enum(AttendanceStatusEnum), nullable=False)
+    minutes_late = Column(SmallInteger)
+    comment = Column(Text)
     student_id = Column(Integer, ForeignKey('students.id', ondelete='CASCADE'), nullable=False)
     academic_year_id = Column(Integer, ForeignKey('academic_years.id', ondelete='CASCADE'), nullable=False)
 

--- a/backend/schemas/attendance.py
+++ b/backend/schemas/attendance.py
@@ -1,10 +1,13 @@
 # backend/schemas/attendance.py
 from pydantic import BaseModel
 from datetime import date
+from models.attendance import AttendanceStatusEnum
 
 class AttendanceBase(BaseModel):
     date: date
-    is_present: bool
+    status: AttendanceStatusEnum
+    minutes_late: int | None = None
+    comment: str | None = None
     student_id: int
 
 class AttendanceCreate(AttendanceBase):

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -109,7 +109,9 @@ This document summarizes the SQLAlchemy models used in the backend.
 - **Columns:**
   - `id` – primary key
   - `date`
-  - `is_present`
+  - `status` (present/absent/sick/late/excused)
+  - `minutes_late`
+  - `comment`
   - `student_id` – FK to `students.id` (CASCADE)
   - `academic_year_id` – FK to `academic_years.id` (CASCADE)
 - **Relationships:** belongs to `Student` and `AcademicYear`.


### PR DESCRIPTION
## Summary
- add AttendanceStatusEnum and status field to Attendance model
- support minutes late and comments
- map russian letters to statuses
- document new attendance fields
- create migration for attendance status enum

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e40987fec83338927ef8a70479535