### PR TITLE
Add lesson events table with foreign key integration

### DIFF
--- a/backend/alembic/versions/d3f2071a88a7_add_lesson_events.py
+++ b/backend/alembic/versions/d3f2071a88a7_add_lesson_events.py
@@ -1,0 +1,61 @@
+"""add lesson events
+
+Revision ID: d3f2071a88a7
+Revises: a1b2c3d4e5f6
+Create Date: 2025-06-27 07:20:02.461162
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd3f2071a88a7'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lesson_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("subject_id", sa.Integer(), nullable=False),
+        sa.Column("class_id", sa.Integer(), nullable=False),
+        sa.Column("lesson_date", sa.Date(), nullable=False),
+        sa.Column("lesson_index", sa.SmallInteger(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["subject_id"], ["subjects.id"]),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"]),
+    )
+    op.add_column(
+        "grades",
+        sa.Column("lesson_event_id", sa.BigInteger(), nullable=False),
+    )
+    op.create_foreign_key(
+        None, "grades", "lesson_events", ["lesson_event_id"], ["id"], ondelete="CASCADE"
+    )
+    op.alter_column("grades", "lesson_event_id", nullable=False)
+    op.add_column(
+        "attendance",
+        sa.Column("lesson_event_id", sa.BigInteger(), nullable=False),
+    )
+    op.create_foreign_key(
+        None, "attendance", "lesson_events", ["lesson_event_id"], ["id"], ondelete="CASCADE"
+    )
+    op.alter_column("attendance", "lesson_event_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, "attendance", type_="foreignkey")
+    op.drop_column("attendance", "lesson_event_id")
+    op.drop_constraint(None, "grades", type_="foreignkey")
+    op.drop_column("grades", "lesson_event_id")
+    op.drop_table("lesson_events")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,6 +1,7 @@
 from .academic_year import AcademicYear
 from .administrator import Administrator
 from .attendance import Attendance, AttendanceStatusEnum
+from .lesson_event import LessonEvent
 from .city import City
 from .class_ import (Class, ClassTeacher, ClassTeacherRole,
                      ClassTeacherRoleAssociation, class_subjects)

--- a/backend/models/attendance.py
+++ b/backend/models/attendance.py
@@ -36,9 +36,15 @@ class Attendance(Base):
     status = Column(Enum(AttendanceStatusEnum), nullable=False)
     minutes_late = Column(SmallInteger)
     comment = Column(Text)
+    lesson_event_id = Column(
+        Integer,
+        ForeignKey('lesson_events.id', ondelete='CASCADE'),
+        nullable=False,
+    )
     student_id = Column(Integer, ForeignKey('students.id', ondelete='CASCADE'), nullable=False)
     academic_year_id = Column(Integer, ForeignKey('academic_years.id', ondelete='CASCADE'), nullable=False)
 
     # Отношения
     student = relationship('Student', back_populates='attendance_records')
     academic_year = relationship('AcademicYear', back_populates='attendance_records')
+    lesson_event = relationship('LessonEvent', back_populates='attendance_records')

--- a/backend/models/grade.py
+++ b/backend/models/grade.py
@@ -33,7 +33,11 @@ class Grade(Base):
     term_type = Column(Enum(TermTypeEnum), nullable=False)
     term_index = Column(SmallInteger, nullable=False)
     grade_kind = Column(Enum(GradeKindEnum), nullable=False)
-    lesson_event_id = Column(Integer, nullable=True)
+    lesson_event_id = Column(
+        Integer,
+        ForeignKey("lesson_events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     student_id = Column(
         Integer,
         ForeignKey("students.id", ondelete="CASCADE"),
@@ -60,6 +64,7 @@ class Grade(Base):
     teacher = relationship("Teacher", back_populates="grades")
     subject = relationship("Subject", back_populates="grades")
     academic_year = relationship("AcademicYear", back_populates="grades")
+    lesson_event = relationship("LessonEvent", back_populates="grades")
 
 
 Index(

--- a/backend/models/lesson_event.py
+++ b/backend/models/lesson_event.py
@@ -1,0 +1,20 @@
+# backend/models/lesson_event.py
+from sqlalchemy import Column, BigInteger, Integer, Date, SmallInteger, ForeignKey, TIMESTAMP, text
+from sqlalchemy.orm import relationship
+from core.db import Base
+
+
+class LessonEvent(Base):
+    __tablename__ = "lesson_events"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    subject_id = Column(Integer, ForeignKey("subjects.id", ondelete="RESTRICT"), nullable=False)
+    class_id = Column(Integer, ForeignKey("classes.id", ondelete="CASCADE"), nullable=False)
+    lesson_date = Column(Date, nullable=False)
+    lesson_index = Column(SmallInteger)
+    created_at = Column(TIMESTAMP, server_default=text("now()"))
+
+    subject = relationship("Subject")
+    school_class = relationship("Class")
+    grades = relationship("Grade", back_populates="lesson_event", cascade="all, delete-orphan")
+    attendance_records = relationship("Attendance", back_populates="lesson_event", cascade="all, delete-orphan")

--- a/backend/schemas/attendance.py
+++ b/backend/schemas/attendance.py
@@ -9,6 +9,7 @@ class AttendanceBase(BaseModel):
     minutes_late: int | None = None
     comment: str | None = None
     student_id: int
+    lesson_event_id: int
 
 class AttendanceCreate(AttendanceBase):
     pass

--- a/backend/schemas/grade.py
+++ b/backend/schemas/grade.py
@@ -14,7 +14,7 @@ class GradeBase(BaseModel):
     term_type: TermTypeEnum
     term_index: int
     grade_kind: GradeKindEnum
-    lesson_event_id: int | None = None
+    lesson_event_id: int
 
 
 class GradeCreate(GradeBase):


### PR DESCRIPTION
## Summary
- create new `lesson_events` table
- reference it from `grades` and `attendance`
- add SQLAlchemy model for lesson events and hook up relationships
- update Grade and Attendance schemas
- generate alembic migration

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e45848da88333826582a72f8d3cd8