### PR TITLE
Add exams schema and service

### DIFF
--- a/backend/alembic/versions/e4b7c1dca9e6_add_exams_table.py
+++ b/backend/alembic/versions/e4b7c1dca9e6_add_exams_table.py
@@ -1,0 +1,35 @@
+"""add exams table
+
+Revision ID: e4b7c1dca9e6
+Revises: d3f2071a88a7
+Create Date: 2025-07-09 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e4b7c1dca9e6'
+down_revision: Union[str, None] = 'd3f2071a88a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'exams',
+        sa.Column('id', sa.BigInteger(), primary_key=True),
+        sa.Column('student_id', sa.BigInteger(), nullable=False),
+        sa.Column('subject_id', sa.BigInteger(), nullable=False),
+        sa.Column('exam_kind', sa.String(length=50), nullable=False),
+        sa.Column('exam_date', sa.Date(), nullable=False),
+        sa.Column('value', sa.SmallInteger(), nullable=True),
+        sa.Column('comment', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['student_id'], ['students.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['subject_id'], ['subjects.id'], ondelete='CASCADE'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('exams')

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -15,3 +15,5 @@ from .subject import Subject
 from .teacher import Teacher
 from .teacher_subject import TeacherSubject
 from .user import RoleEnum, User
+
+from .exam import Exam, ExamKindEnum

--- a/backend/models/exam.py
+++ b/backend/models/exam.py
@@ -1,0 +1,24 @@
+import enum
+from sqlalchemy import Column, BigInteger, Integer, ForeignKey, SmallInteger, Date, Text, Enum
+from sqlalchemy.orm import relationship
+from core.db import Base
+
+
+class ExamKindEnum(str, enum.Enum):
+    exam = "exam"
+    state_exam = "state_exam"
+
+
+class Exam(Base):
+    __tablename__ = "exams"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    student_id = Column(BigInteger, ForeignKey("students.id", ondelete="CASCADE"), nullable=False)
+    subject_id = Column(BigInteger, ForeignKey("subjects.id", ondelete="CASCADE"), nullable=False)
+    exam_kind = Column(Enum(ExamKindEnum), nullable=False)
+    exam_date = Column(Date, nullable=False)
+    value = Column(SmallInteger)
+    comment = Column(Text)
+
+    student = relationship("Student")
+    subject = relationship("Subject")

--- a/backend/repositories/__init__.py
+++ b/backend/repositories/__init__.py
@@ -4,3 +4,4 @@ from .city_repository import CityRepository
 from .school_repository import SchoolRepository
 from .academic_year_repository import AcademicYearRepository
 
+from .exam_repository import ExamRepository

--- a/backend/repositories/exam_repository.py
+++ b/backend/repositories/exam_repository.py
@@ -1,0 +1,17 @@
+from sqlalchemy.orm import Session
+
+from models.exam import Exam
+from schemas.exam import ExamIn
+
+
+class ExamRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_bulk(self, exams: list[ExamIn]) -> list[Exam]:
+        objects = [Exam(**e.dict()) for e in exams]
+        self.db.add_all(objects)
+        self.db.commit()
+        for obj in objects:
+            self.db.refresh(obj)
+        return objects

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,2 +1,3 @@
 from .user import UserCreate, UserRead, Token
 
+from .exam import ExamIn

--- a/backend/schemas/exam.py
+++ b/backend/schemas/exam.py
@@ -1,0 +1,12 @@
+from datetime import date
+from pydantic import BaseModel
+from models.exam import ExamKindEnum
+
+
+class ExamIn(BaseModel):
+    student_id: int
+    subject_id: int
+    exam_kind: ExamKindEnum
+    exam_date: date
+    value: int | None = None
+    comment: str | None = None

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+from .exam_service import ExamService

--- a/backend/services/exam_service.py
+++ b/backend/services/exam_service.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import Session
+from schemas.exam import ExamIn
+from repositories.exam_repository import ExamRepository
+
+
+class ExamService:
+    def __init__(self, db: Session):
+        self.repo = ExamRepository(db)
+
+    def create_bulk(self, exams: list[ExamIn]):
+        return self.repo.create_bulk(exams)


### PR DESCRIPTION
## Summary
- add Exam model and migration
- create ExamIn schema
- implement repository and service with bulk creation

## Testing
- `pytest -q tests/test_teacher_import.py::test_import_happy_path -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685e4a662ca883338b517af01b0938f7