### PR TITLE
Implement subject aliases

### DIFF
--- a/app/import_aliases/__init__.py
+++ b/app/import_aliases/__init__.py
@@ -1,0 +1,1 @@
+from .service import import_aliases_from_file

--- a/app/import_aliases/service.py
+++ b/app/import_aliases/service.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from models import Subject
+from repositories.subject_alias_repository import SubjectAliasRepository
+from backend.services import resolve_subject
+
+
+def import_aliases_from_file(path: str, db: Session) -> int:
+    """Import subject aliases from CSV or XLSX file.
+
+    Expected columns: alias, subject
+    Returns number of aliases imported.
+    """
+    if path.lower().endswith(".csv"):
+        df = pd.read_csv(path)
+    elif path.lower().endswith(".xlsx"):
+        df = pd.read_excel(path)
+    else:
+        raise ValueError("unsupported file format")
+
+    repo = SubjectAliasRepository(db)
+    count = 0
+    for _, row in df.iterrows():
+        alias = str(row.get("alias") or row.get("Alias") or row[0]).strip()
+        subject_name = str(row.get("subject") or row.get("Subject") or row[1]).strip()
+        if not alias or not subject_name:
+            continue
+        subject = resolve_subject(db, subject_name)
+        if subject is None:
+            continue
+        if repo.get_by_alias(alias) is None:
+            repo.create(alias, subject)
+            count += 1
+    return count
+

--- a/app/import_teachers/service.py
+++ b/app/import_teachers/service.py
@@ -21,6 +21,7 @@ from models import (
     Teacher,
     TeacherSubject,
 )
+from backend.services import resolve_subject
 
 logger = structlog.get_logger(__name__)
 
@@ -103,11 +104,7 @@ def _handle_row(
 
         subject = subject_cache.get(subject_name)
         if subject is None:
-            subject = (
-                db.query(Subject)
-                .filter_by(name=subject_name, school_id=school_id)
-                .first()
-            )
+            subject = resolve_subject(db, subject_name)
             if subject is None:
                 subject = Subject(name=subject_name, school_id=school_id)
                 db.add(subject)

--- a/backend/alembic/versions/da2c6a68a1cc_add_subject_aliases.py
+++ b/backend/alembic/versions/da2c6a68a1cc_add_subject_aliases.py
@@ -1,0 +1,33 @@
+"""add subject aliases
+
+Revision ID: da2c6a68a1cc
+Revises: e4b7c1dca9e6
+Create Date: 2025-06-27 08:02:06.682786
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'da2c6a68a1cc'
+down_revision: Union[str, None] = 'e4b7c1dca9e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'subject_aliases',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('alias', sa.Text(), nullable=False),
+        sa.Column('subject_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['subject_id'], ['subjects.id'], ondelete='CASCADE'),
+        sa.UniqueConstraint('alias'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('subject_aliases')

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,6 +12,7 @@ from .schedule import Schedule
 from .school import School
 from .student import Student
 from .subject import Subject
+from .subject_alias import SubjectAlias
 from .teacher import Teacher
 from .teacher_subject import TeacherSubject
 from .user import RoleEnum, User

--- a/backend/models/subject.py
+++ b/backend/models/subject.py
@@ -23,3 +23,8 @@ class Subject(Base):
         cascade='all, delete-orphan'
     )
     classes = relationship('Class', secondary='class_subjects', back_populates='subjects')
+    aliases = relationship(
+        'SubjectAlias',
+        back_populates='subject',
+        cascade='all, delete-orphan'
+    )

--- a/backend/models/subject_alias.py
+++ b/backend/models/subject_alias.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
+from core.db import Base
+
+
+class SubjectAlias(Base):
+    __tablename__ = "subject_aliases"
+
+    id = Column(Integer, primary_key=True)
+    alias = Column(Text, unique=True, nullable=False)
+    subject_id = Column(Integer, ForeignKey("subjects.id", ondelete="CASCADE"), nullable=False)
+
+    subject = relationship("Subject", back_populates="aliases")
+

--- a/backend/repositories/__init__.py
+++ b/backend/repositories/__init__.py
@@ -5,3 +5,4 @@ from .school_repository import SchoolRepository
 from .academic_year_repository import AcademicYearRepository
 
 from .exam_repository import ExamRepository
+from .subject_alias_repository import SubjectAliasRepository

--- a/backend/repositories/subject_alias_repository.py
+++ b/backend/repositories/subject_alias_repository.py
@@ -1,0 +1,18 @@
+from sqlalchemy.orm import Session
+from models import SubjectAlias, Subject
+
+
+class SubjectAliasRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_alias(self, alias: str) -> SubjectAlias | None:
+        return self.db.query(SubjectAlias).filter_by(alias=alias).first()
+
+    def create(self, alias: str, subject: Subject) -> SubjectAlias:
+        obj = SubjectAlias(alias=alias, subject=subject)
+        self.db.add(obj)
+        self.db.commit()
+        self.db.refresh(obj)
+        return obj
+

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,1 +1,2 @@
 from .exam_service import ExamService
+from .subject_service import resolve_subject

--- a/backend/services/subject_service.py
+++ b/backend/services/subject_service.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+
+from models import Subject, SubjectAlias
+
+
+def resolve_subject(db: Session, name: str) -> Subject | None:
+    subject = db.query(Subject).filter_by(name=name).first()
+    if subject:
+        return subject
+    alias = db.query(SubjectAlias).filter_by(alias=name).first()
+    if alias:
+        return alias.subject
+    return None
+

--- a/manage
+++ b/manage
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from app.cli import main
+import sys
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add SubjectAlias model and migration
- implement resolve_subject service
- support subject synonyms in teacher import
- create import-aliases CLI command
- add simple manage script

## Testing
- `pytest -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685e4f358f788333968d39e961f0c5c2