### PR TITLE
Implement ImportService for bulk grade/attendance upserts

### DIFF
--- a/app/importer/service.py
+++ b/app/importer/service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from sqlalchemy import tuple_
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from backend.schemas.grade import GradeCreate
+from backend.schemas.attendance import AttendanceCreate
+from models.grade import Grade
+from models.attendance import Attendance
+
+from .base import BaseParser
+from .constants import ImportSummary
+
+
+class ImportService:
+    """Bulk import grades and attendance records."""
+
+    def __init__(self, db: Session, *, dry_run: bool = False) -> None:
+        self.db = db
+        self.dry_run = dry_run
+
+    def _upsert_grades(self, grades: Sequence[GradeCreate]) -> ImportSummary:
+        summary = ImportSummary()
+        if not grades:
+            return summary
+
+        values = [g.model_dump() for g in grades]
+        keys = [
+            (
+                g.student_id,
+                g.subject_id,
+                g.term_type,
+                g.term_index,
+                g.grade_kind,
+                g.lesson_event_id,
+            )
+            for g in grades
+        ]
+        existing = set(
+            self.db.query(
+                Grade.student_id,
+                Grade.subject_id,
+                Grade.term_type,
+                Grade.term_index,
+                Grade.grade_kind,
+                Grade.lesson_event_id,
+            )
+            .filter(
+                tuple_(
+                    Grade.student_id,
+                    Grade.subject_id,
+                    Grade.term_type,
+                    Grade.term_index,
+                    Grade.grade_kind,
+                    Grade.lesson_event_id,
+                ).in_(keys)
+            )
+            .all()
+        )
+        for key in keys:
+            if key in existing:
+                summary.updated += 1
+            else:
+                summary.created += 1
+
+        if not self.dry_run:
+            stmt = insert(Grade).values(values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[
+                    Grade.student_id,
+                    Grade.subject_id,
+                    Grade.term_type,
+                    Grade.term_index,
+                    Grade.grade_kind,
+                    Grade.lesson_event_id,
+                ],
+                set_={"value": stmt.excluded.value},
+            )
+            self.db.execute(stmt)
+        return summary
+
+    def _upsert_attendance(self, records: Sequence[AttendanceCreate]) -> ImportSummary:
+        summary = ImportSummary()
+        if not records:
+            return summary
+
+        values = [r.model_dump() for r in records]
+        keys = [(r.student_id, r.date) for r in records]
+        existing = set(
+            self.db.query(Attendance.student_id, Attendance.date)
+            .filter(tuple_(Attendance.student_id, Attendance.date).in_(keys))
+            .all()
+        )
+        for key in keys:
+            if key in existing:
+                summary.updated += 1
+            else:
+                summary.created += 1
+
+        if not self.dry_run:
+            stmt = insert(Attendance).values(values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[Attendance.student_id, Attendance.date],
+                set_={
+                    "status": stmt.excluded.status,
+                    "minutes_late": stmt.excluded.minutes_late,
+                },
+            )
+            self.db.execute(stmt)
+        return summary
+
+    def import_items(self, items: Iterable[object]) -> ImportSummary:
+        summary = ImportSummary()
+        grades: list[GradeCreate] = []
+        attendance: list[AttendanceCreate] = []
+        for item in items:
+            if isinstance(item, GradeCreate):
+                grades.append(item)
+            elif isinstance(item, AttendanceCreate):
+                attendance.append(item)
+        summary += self._upsert_grades(grades)
+        summary += self._upsert_attendance(attendance)
+        if self.dry_run:
+            self.db.rollback()
+        else:
+            self.db.commit()
+        return summary
+
+    def import_from_parser(self, parser: BaseParser) -> ImportSummary:
+        summary = ImportSummary()
+        for batch in parser.iter_batches():
+            summary += self.import_items(batch)
+        return summary


### PR DESCRIPTION
## Summary
- add `ImportService` with batch upsert logic for `Grade` and `Attendance`
- support dry-run mode for validation without DB writes

## Testing
- `pytest tests/test_progress_report_parser.py::test_progress_report_parser -q`
- *(failure)* `pytest tests/test_import_service.py::test_import_service_upsert -q` *(missing initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685ec21d597c8333809497a0c18de864