### PR TITLE
Add import router with parser selection

### DIFF
--- a/app/importer/router.py
+++ b/app/importer/router.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+import tempfile
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from sqlalchemy.orm import Session
+
+from backend.core.db import get_db
+from .mark_sheet_parser import MarkSheetParser
+from .progress_report_parser import ProgressReportParser
+from .service import ImportService, ImportReport
+
+
+class ParserType(str, Enum):
+    mark_sheet = "mark_sheet"
+    progress_report = "progress_report"
+
+
+router = APIRouter()
+
+
+@router.post("/import")
+async def import_endpoint(
+    parser_type: ParserType = Query(...),
+    file: UploadFile = File(...),
+    dry_run: bool = Query(False),
+    db: Session = Depends(get_db),
+):
+    tmp_dir = Path(tempfile.gettempdir())
+    tmp_path = tmp_dir / f"{uuid4()}.xlsx"
+    tmp_path.write_bytes(await file.read())
+
+    try:
+        if parser_type is ParserType.mark_sheet:
+            parser = MarkSheetParser(str(tmp_path))
+        elif parser_type is ParserType.progress_report:
+            parser = ProgressReportParser(str(tmp_path))
+        else:
+            raise HTTPException(status_code=400, detail="unknown parser type")
+
+        service = ImportService(db, dry_run=dry_run)
+        summary = service.import_from_parser(parser)
+        report = ImportReport.model_validate(summary.__dict__)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return {"dry_run": dry_run, **report.model_dump()}

--- a/app/importer/service.py
+++ b/app/importer/service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Iterable, Sequence
 
+from pydantic import BaseModel
+
 from sqlalchemy import tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
@@ -13,6 +15,17 @@ from models.attendance import Attendance
 
 from .base import BaseParser
 from .constants import ImportSummary
+
+
+class ImportReport(BaseModel):
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: list[str] = []
+
+    @classmethod
+    def from_summary(cls, summary: ImportSummary) -> "ImportReport":
+        return cls(**summary.__dict__)
 
 
 class ImportService:

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from routers.academic_year_router import router as academic_year_router
 from routers.user_router import router as user_router
 from routers.auth_router import router as auth_router
 from app.import_teachers.router import router as import_teachers_router
+from app.importer.router import router as importer_router
 
 
 from fastapi.middleware.cors import CORSMiddleware 
@@ -68,6 +69,7 @@ app.include_router(academic_year_router)
 app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(import_teachers_router)
+app.include_router(importer_router)
 
 # При необходимости создания таблиц без миграций
 # Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- add `ImportReport` schema for importer
- implement `import` router to parse uploaded files
- register importer router in FastAPI app

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pydantic-settings`
- `pip install -q 'fastapi>=0.110'`
- `pytest -q` *(fails: command not found `initdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685fa87b16cc8333b78312d894f10018