### PR TITLE
Add structlog logging for importer service

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,47 @@
+import logging
+from logging.config import dictConfig
+
+import structlog
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": [
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.processors.format_exc_info,
+            ],
+        },
+    },
+    "handlers": {
+        "default": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+            "level": "INFO",
+        },
+    },
+    "loggers": {
+        "": {"handlers": ["default"], "level": "INFO"},
+    },
+}
+
+
+def configure_logging() -> None:
+    """Configure structlog and standard logging."""
+    dictConfig(LOGGING)
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        cache_logger_on_first_use=True,
+    )
+

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,6 +1,5 @@
 # backend/core/config.py
-from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- configure JSON logging in `app/logging.py`
- integrate structlog in `ImportService`
- use pydantic BaseSettings directly

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_685faee9df948333b2ac14a004ddb6c4