### PR TITLE
Add parser utils and tests

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,5 +1,6 @@
 # backend/core/config.py
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):

--- a/tests/test_mark_sheet_parser.py
+++ b/tests/test_mark_sheet_parser.py
@@ -43,3 +43,14 @@ def test_mark_sheet_parser(tmp_path):
     assert first.grade_kind == GradeKindEnum.period_final
     assert first.value == 5
     assert first.lesson_event_id is None
+
+def test_map_columns():
+    df = pd.DataFrame([["Предмет", "1 четверть", "1 четверть ср", "2 четверть", "Год"]])
+    parser = MarkSheetParser("dummy")
+    mapping = parser._map_columns(df.iloc[0])
+    assert mapping == {
+        1: (TermTypeEnum.quarter, 1, GradeKindEnum.period_final),
+        2: (TermTypeEnum.quarter, 1, GradeKindEnum.avg),
+        3: (TermTypeEnum.quarter, 2, GradeKindEnum.period_final),
+        4: (TermTypeEnum.year, 1, GradeKindEnum.year_final),
+    }

--- a/tests/test_split_cell.py
+++ b/tests/test_split_cell.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.importer.constants import split_cell
+
+
+def test_split_cell_basic():
+    assert split_cell("Н/5") == ["Н", "5"]
+
+
+def test_split_cell_empty():
+    assert split_cell("") == []
+
+
+def test_split_cell_duplicates():
+    assert split_cell("5/5/Н") == ["5", "5", "Н"]


### PR DESCRIPTION
## Summary
- add `_map_columns` helper to `MarkSheetParser`
- improve period detection in `ProgressReportParser`
- migrate settings to `pydantic-settings`
- test `split_cell` edge cases
- unit test column mapping

## Testing
- `pytest tests/test_split_cell.py tests/test_mark_sheet_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685fb20982208333901bf69f403da2ab