### PR TITLE
Add entity resolver helpers

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,2 +1,7 @@
 from .exam_service import ExamService
 from .subject_service import resolve_subject
+from .entity_service import (
+    resolve_or_create_student,
+    resolve_or_create_class,
+    resolve_or_create_year,
+)

--- a/backend/services/entity_service.py
+++ b/backend/services/entity_service.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import date
+import re
+from sqlalchemy.orm import Session
+
+from models import AcademicYear, Class, Student
+
+
+def resolve_or_create_year(db: Session, name: str) -> int:
+    """Return ID of academic year with given name, create if missing."""
+    ay = db.query(AcademicYear).filter_by(name=name).first()
+    if ay is None:
+        m = re.search(r"(\d{4})/(\d{4})", name)
+        if m:
+            start_year, end_year = int(m.group(1)), int(m.group(2))
+            ay = AcademicYear(
+                name=name,
+                year_start=date(start_year, 9, 1),
+                year_end=date(end_year, 8, 31),
+            )
+        else:
+            ay = AcademicYear(
+                name=name,
+                year_start=date.today(),
+                year_end=date.today(),
+            )
+        db.add(ay)
+        db.flush([ay])
+    return ay.id
+
+
+def resolve_or_create_class(
+    db: Session, name: str, school_id: int, academic_year_id: int
+) -> int:
+    """Return ID of class by name and school, create if missing."""
+    cls = (
+        db.query(Class)
+        .filter_by(name=name, school_id=school_id, academic_year_id=academic_year_id)
+        .first()
+    )
+    if cls is None:
+        cls = Class(
+            name=name,
+            school_id=school_id,
+            academic_year_id=academic_year_id,
+        )
+        db.add(cls)
+        db.flush([cls])
+    return cls.id
+
+
+def resolve_or_create_student(
+    db: Session,
+    full_name: str,
+    school_id: int,
+    class_id: int,
+    class_name: str,
+) -> int:
+    """Return ID of student by name and school, create if missing."""
+    student = (
+        db.query(Student)
+        .filter_by(full_name=full_name, school_id=school_id)
+        .first()
+    )
+    if student is None:
+        student = Student(
+            full_name=full_name,
+            class_name=class_name,
+            class_id=class_id,
+            school_id=school_id,
+        )
+        db.add(student)
+        db.flush([student])
+    return student.id

--- a/tests/test_entity_service.py
+++ b/tests/test_entity_service.py
@@ -1,0 +1,88 @@
+import os
+import sys
+from pathlib import Path
+
+import testing.postgresql
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+os.environ.setdefault("DATABASE_URL", "postgresql://localhost/db")
+os.environ.setdefault("SECRET_KEY", "x")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_NAME", "db")
+os.environ.setdefault("DB_USER", "user")
+os.environ.setdefault("DB_PASSWORD", "pass")
+
+from backend.services import (
+    resolve_or_create_student,
+    resolve_or_create_class,
+    resolve_or_create_year,
+)
+from models import Region, City, School, Class, Student, AcademicYear
+
+
+def run_migrations(url: str) -> None:
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, "head")
+
+
+def prepare_school(session):
+    region = Region(name="R")
+    city = City(name="C", region=region)
+    school = School(name="S", full_name="Test School", city=city)
+    session.add_all([region, city, school])
+    session.commit()
+    return school.id
+
+
+def test_resolve_helpers_create_and_reuse(tmp_path):
+    with testing.postgresql.Postgresql() as pg:
+        run_migrations(pg.url())
+        engine = create_engine(pg.url())
+        Session = sessionmaker(bind=engine)
+        session = Session()
+        school_id = prepare_school(session)
+
+        year_id = resolve_or_create_year(session, "2024/2025")
+        session.commit()
+        assert session.query(AcademicYear).count() == 1
+        year_id2 = resolve_or_create_year(session, "2024/2025")
+        session.commit()
+        assert year_id2 == year_id
+        assert session.query(AcademicYear).count() == 1
+
+        class_id = resolve_or_create_class(session, "1A", school_id, year_id)
+        session.commit()
+        assert session.query(Class).count() == 1
+        class_id2 = resolve_or_create_class(session, "1A", school_id, year_id)
+        session.commit()
+        assert class_id2 == class_id
+        assert session.query(Class).count() == 1
+
+        student_id = resolve_or_create_student(
+            session,
+            "Kid",
+            school_id,
+            class_id,
+            "1A",
+        )
+        session.commit()
+        assert session.query(Student).count() == 1
+        student_id2 = resolve_or_create_student(
+            session,
+            "Kid",
+            school_id,
+            class_id,
+            "1A",
+        )
+        session.commit()
+        assert student_id2 == student_id
+        assert session.query(Student).count() == 1
+        session.close()


### PR DESCRIPTION
## Summary
- add resolver helpers for classes, students and academic years
- export helpers in service package
- test creation and reuse of these helpers

## Testing
- `pytest tests/test_entity_service.py -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_686669cc1b90833381be87d6dd2220ea