### PR TITLE
Update import service to resolve ParsedRow entities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 openpyxl
 structlog
 testing.postgresql
+pydantic-settings


### PR DESCRIPTION
## Summary
- extend ImportService to work with ParsedRow objects
- resolve academic year, class, student and subject on import
- create lesson events when needed
- update import service test accordingly
- add pydantic-settings to requirements

## Testing
- `pytest tests/test_import_service.py::test_import_service_sets_year -q` *(fails: initdb failed because running as root)*

------
https://chatgpt.com/codex/tasks/task_e_68666e18164083338375a5762af10b63