### PR TITLE
Handle weighted average in mark sheet parser

### DIFF
--- a/app/importer/mark_sheet_parser.py
+++ b/app/importer/mark_sheet_parser.py
@@ -82,7 +82,9 @@ class MarkSheetParser(BaseParser):
             term_index = int(m.group(1))
         else:
             term_index = 1
-        if "ср" in s or "avg" in s or "бал" in s:
+        if "взв" in s or "взвеш" in s:
+            grade_kind = GradeKindEnum.weighted_avg
+        elif "ср" in s or "avg" in s or "бал" in s:
             grade_kind = GradeKindEnum.avg
         else:
             grade_kind = GradeKindEnum.period_final

--- a/tests/test_mark_sheet_parser.py
+++ b/tests/test_mark_sheet_parser.py
@@ -125,3 +125,15 @@ def test_parser_multiline_header(tmp_path):
     parser = MarkSheetParser(str(file))
     items = list(parser.parse())
     assert len(items) == 6  # 2 subjects * (2 quarters + year)
+
+
+def test_map_columns_weighted_avg():
+    df = pd.DataFrame([["Предмет", "1 четверть", "1 четверть ср взв"]])
+    parser = MarkSheetParser("dummy")
+    headers = df.iloc[0]
+    subj_col = parser._find_subject_column(headers)
+    mapping = parser._map_columns(df, 0, subj_col)
+    assert mapping == {
+        1: (TermTypeEnum.quarter, 1, GradeKindEnum.period_final),
+        2: (TermTypeEnum.quarter, 1, GradeKindEnum.weighted_avg),
+    }


### PR DESCRIPTION
## Summary
- support `weighted_avg` grade kind in mark sheet parser
- test header mapping for weighted average columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68668922e5d883338d5290c99083aed4