### PR TITLE
Handle compact grade headers

### DIFF
--- a/app/importer/mark_sheet_parser.py
+++ b/app/importer/mark_sheet_parser.py
@@ -112,6 +112,8 @@ class MarkSheetParser(BaseParser):
                 rows.append(df.iloc[header_idx + i])
 
         mapping: Dict[int, Tuple[TermTypeEnum, int, GradeKindEnum]] = {}
+        last_tt: TermTypeEnum | None = None
+        last_ti: int | None = None
         for col in range(subject_col + 1, len(df.columns)):
             parts = []
             for row in rows:
@@ -122,8 +124,14 @@ class MarkSheetParser(BaseParser):
                         parts.append(val)
             header_text = " ".join(parts)
             term_type, term_index, grade_kind = self._parse_header(header_text)
+            if term_type is None:
+                term_type = last_tt
+            if term_index is None:
+                term_index = last_ti
             if term_type is not None and grade_kind is not None:
-                mapping[col] = (term_type, term_index, grade_kind)
+                mapping[col] = (term_type, term_index or 1, grade_kind)
+                last_tt = term_type
+                last_ti = term_index
         return mapping
 
     def parse(self) -> Iterator[ParsedRow]:

--- a/tests/test_mark_sheet_parser.py
+++ b/tests/test_mark_sheet_parser.py
@@ -137,3 +137,23 @@ def test_map_columns_weighted_avg():
         1: (TermTypeEnum.quarter, 1, GradeKindEnum.period_final),
         2: (TermTypeEnum.quarter, 1, GradeKindEnum.weighted_avg),
     }
+
+
+def test_map_columns_missing_period_info():
+    df = pd.DataFrame(
+        [
+            ["Предмет", "Учебные периоды", None, None],
+            ["№", None, None, None],
+            ["п/п", "1 четверть", None, None],
+            [None, "Средний балл", "Ср. взв. балл", "Итог"],
+        ]
+    )
+    parser = MarkSheetParser("dummy")
+    headers = df.iloc[0]
+    subj_col = parser._find_subject_column(headers)
+    mapping = parser._map_columns(df, 0, subj_col)
+    assert mapping == {
+        1: (TermTypeEnum.quarter, 1, GradeKindEnum.avg),
+        2: (TermTypeEnum.quarter, 1, GradeKindEnum.weighted_avg),
+        3: (TermTypeEnum.quarter, 1, GradeKindEnum.period_final),
+    }


### PR DESCRIPTION
## Summary
- support grade headers that omit period information for some columns
- test parser with missing period headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_68668b12a1c48333976f15980771e635