### PR TITLE
Add helper for quarter term in progress report parser

### DIFF
--- a/tests/test_progress_report_parser.py
+++ b/tests/test_progress_report_parser.py
@@ -43,6 +43,10 @@ def test_progress_report_parser(tmp_path):
     assert items[0].attendance_status == "absent"
     assert isinstance(items[1], ParsedRow)
     assert items[1].grade_kind == GradeKindEnum.regular.value
+    assert items[1].term_type == "quarter"
+    assert items[1].term_index == 1
     assert items[1].grade_value == 5
     assert isinstance(items[2], ParsedRow)
+    assert items[2].term_type == "quarter"
+    assert items[2].term_index == 1
     assert items[2].grade_value == 4


### PR DESCRIPTION
## Summary
- map lesson dates to school quarters for progress report parser
- use new helper when generating grade rows
- update progress report parser unit test

## Testing
- `pytest tests/test_progress_report_parser.py::test_progress_report_parser -q` *(fails: ModuleNotFoundError: No module named 'pydantic._internal')*

------
https://chatgpt.com/codex/tasks/task_e_6866bded1c3c83338b5f6880ff039d25