### PR TITLE
Update period parsing

### DIFF
--- a/tests/test_progress_report_parser.py
+++ b/tests/test_progress_report_parser.py
@@ -40,6 +40,7 @@ def test_progress_report_parser(tmp_path):
     items = [item for batch in batches for item in batch]
     assert len(items) == 3
     assert isinstance(items[0], ParsedRow)
+    assert items[0].academic_year_name == "2024/2025"
     assert items[0].attendance_status == "absent"
     assert isinstance(items[1], ParsedRow)
     assert items[1].grade_kind == GradeKindEnum.regular.value


### PR DESCRIPTION
## Summary
- compute academic year when reading period row
- add academic year assertion in report parser tests

## Testing
- `pytest tests/test_progress_report_parser.py -q`
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf965184833392fa928153feeffb