### PR TITLE
Add unique constraint to attendance

### DIFF
--- a/backend/alembic/versions/ad004e2829b1_add_attendance_unique_constraint.py
+++ b/backend/alembic/versions/ad004e2829b1_add_attendance_unique_constraint.py
@@ -1,0 +1,23 @@
+"""add unique constraint for attendance student/date
+
+Revision ID: ad004e2829b1
+Revises: 51f043c35f8f
+Create Date: 2025-07-10 00:00:00
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ad004e2829b1'
+down_revision: Union[str, Sequence[str], None] = '51f043c35f8f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint('uix_student_date', 'attendance', ['student_id', 'date'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uix_student_date', 'attendance', type_='unique')

--- a/backend/models/attendance.py
+++ b/backend/models/attendance.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     ForeignKey,
     SmallInteger,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from core.db import Base
@@ -30,6 +31,10 @@ STATUS_CHAR_MAP = {
 
 class Attendance(Base):
     __tablename__ = 'attendance'
+
+    __table_args__ = (
+        UniqueConstraint('student_id', 'date', name='uix_student_date'),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     date = Column(Date, nullable=False)


### PR DESCRIPTION
## Summary
- ensure attendance records are unique per student/date
- create Alembic revision to add the database constraint

## Testing
- `pytest -q` *(fails: No module named 'testing', 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866c444c6f883339d45526dee321d45