### PR TITLE
Add academic periods and parser lookup

### DIFF
--- a/app/importer/progress_report_parser.py
+++ b/app/importer/progress_report_parser.py
@@ -31,10 +31,17 @@ MONTH_MAP = {
 class ProgressReportParser(BaseParser):
     """Parse progress report tables exported to XLSX."""
 
-    def __init__(self, path: str, class_id: int = 0, subject_map: Dict[str, int] | None = None) -> None:
+    def __init__(
+        self,
+        path: str,
+        class_id: int = 0,
+        subject_map: Dict[str, int] | None = None,
+        periods: List | None = None,
+    ) -> None:
         self.path = path
         self.class_id = class_id
         self.subject_map = subject_map or {}
+        self.periods = periods or []
         self._event_cache: Dict[Tuple[date, int, int], int] = {}
         self._next_event_id = 1
 
@@ -115,6 +122,10 @@ class ProgressReportParser(BaseParser):
         quarter 2, January-March to quarter 3 and April-May to quarter 4. If the
         date falls outside of these ranges, it is treated as a year grade.
         """
+
+        for p in self.periods:
+            if p.start_date <= lesson_date <= p.end_date:
+                return p.term_type, p.term_index
 
         month = lesson_date.month
         if month in (9, 10):

--- a/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
+++ b/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
@@ -1,0 +1,35 @@
+"""add academic periods table
+
+Revision ID: b754354c5821
+Revises: ad004e2829b1
+Create Date: 2025-09-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'b754354c5821'
+down_revision: Union[str, None] = 'ad004e2829b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'academic_periods',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('academic_year_id', sa.Integer(), nullable=False),
+        sa.Column('term_type', sa.Enum('trimester', 'quarter', 'semester', 'year', name='term_type_enum'), nullable=False),
+        sa.Column('term_index', sa.SmallInteger(), nullable=False),
+        sa.Column('start_date', sa.Date(), nullable=False),
+        sa.Column('end_date', sa.Date(), nullable=False),
+        sa.ForeignKeyConstraint(['academic_year_id'], ['academic_years.id'], ondelete='CASCADE'),
+    )
+    op.create_index(op.f('ix_academic_periods_id'), 'academic_periods', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_academic_periods_id'), table_name='academic_periods')
+    op.drop_table('academic_periods')

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -17,4 +17,6 @@ from .teacher import Teacher
 from .teacher_subject import TeacherSubject
 from .user import RoleEnum, User
 
+from .academic_period import AcademicPeriod
+
 from .exam import Exam, ExamKindEnum

--- a/backend/models/academic_period.py
+++ b/backend/models/academic_period.py
@@ -1,0 +1,20 @@
+# backend/models/academic_period.py
+from sqlalchemy import Column, Integer, Date, Enum, ForeignKey, SmallInteger
+from sqlalchemy.orm import relationship
+
+from core.db import Base
+from models.grade import TermTypeEnum
+
+class AcademicPeriod(Base):
+    __tablename__ = "academic_periods"
+
+    id = Column(Integer, primary_key=True, index=True)
+    academic_year_id = Column(
+        Integer, ForeignKey("academic_years.id", ondelete="CASCADE"), nullable=False
+    )
+    term_type = Column(Enum(TermTypeEnum), nullable=False)
+    term_index = Column(SmallInteger, nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+
+    academic_year = relationship("AcademicYear", back_populates="periods")

--- a/backend/models/academic_year.py
+++ b/backend/models/academic_year.py
@@ -18,3 +18,4 @@ class AcademicYear(Base):
     classes = relationship('Class', back_populates='academic_year', cascade='all, delete-orphan')
     teacher_subjects = relationship('TeacherSubject', back_populates='academic_year', cascade='all, delete-orphan')
     class_teachers = relationship('ClassTeacher', back_populates='academic_year', cascade='all, delete-orphan')
+    periods = relationship('AcademicPeriod', back_populates='academic_year', cascade='all, delete-orphan')


### PR DESCRIPTION
## Summary
- add `AcademicPeriod` model and alembic migration
- link periods to `AcademicYear`
- enable `ProgressReportParser` to use predefined periods

## Testing
- `pytest tests/test_progress_report_parser.py -q`
- `pytest tests/test_progress_report_parser.py::test_get_term_info_with_periods -q`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68676d7352348333976269fc4678ef84