### PR TITLE
Fix enum reuse in migration

### DIFF
--- a/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
+++ b/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 revision: str = 'b754354c5821'
 down_revision: Union[str, None] = 'ad004e2829b1'
@@ -17,7 +18,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    term_type_enum = sa.Enum(
+    term_type_enum = postgresql.ENUM(
         'trimester',
         'quarter',
         'semester',


### PR DESCRIPTION
## Summary
- correct Postgres enum usage for academic_periods

## Testing
- `pytest -q` *(fails: initdb failed because cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_686773558dfc8333a6731ad7afdbeff4