### PR TITLE
Fix duplicate index in migration

### DIFF
--- a/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
+++ b/backend/alembic/versions/b754354c5821_add_academic_periods_table.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
     )
     op.create_table(
         'academic_periods',
-        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('academic_year_id', sa.Integer(), nullable=False),
         sa.Column('term_type', term_type_enum, nullable=False),
         sa.Column('term_index', sa.SmallInteger(), nullable=False),


### PR DESCRIPTION
## Summary
- ensure `academic_periods.id` column doesn't auto-create an index

## Testing
- `pytest -q` *(fails: RuntimeError: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_686774946d4c83338e6b892fe4620d67