### PR TITLE
Add academic period API modules

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from routers.region_router import router as region_router
 from routers.city_router import router as city_router
 from routers.school_router import router as school_router
 from routers.academic_year_router import router as academic_year_router
+from routers.academic_period_router import router as academic_period_router
 from routers.user_router import router as user_router
 from routers.auth_router import router as auth_router
 from app.import_teachers.router import router as import_teachers_router
@@ -66,6 +67,7 @@ app.include_router(region_router)
 app.include_router(city_router)
 app.include_router(school_router)
 app.include_router(academic_year_router)
+app.include_router(academic_period_router)
 app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(import_teachers_router)

--- a/backend/repositories/academic_period_repository.py
+++ b/backend/repositories/academic_period_repository.py
@@ -1,0 +1,38 @@
+# backend/repositories/academic_period_repository.py
+from sqlalchemy.orm import Session
+
+from models.academic_period import AcademicPeriod
+from schemas.academic_period import AcademicPeriodCreate
+
+
+class AcademicPeriodRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get(self, period_id: int) -> AcademicPeriod | None:
+        return self.db.query(AcademicPeriod).filter(AcademicPeriod.id == period_id).first()
+
+    def get_all(self, skip: int = 0, limit: int = 100):
+        return self.db.query(AcademicPeriod).offset(skip).limit(limit).all()
+
+    def create(self, period: AcademicPeriodCreate) -> AcademicPeriod:
+        db_period = AcademicPeriod(**period.dict())
+        self.db.add(db_period)
+        self.db.commit()
+        self.db.refresh(db_period)
+        return db_period
+
+    def update(self, period_id: int, updates: dict) -> AcademicPeriod:
+        db_period = self.get(period_id)
+        for key, value in updates.items():
+            setattr(db_period, key, value)
+        self.db.commit()
+        self.db.refresh(db_period)
+        return db_period
+
+    def delete(self, period_id: int) -> None:
+        db_period = self.get(period_id)
+        if db_period:
+            self.db.delete(db_period)
+            self.db.commit()
+

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -3,6 +3,7 @@ from .region_router import router as region_router
 from .city_router import router as city_router
 from .school_router import router as school_router
 from .academic_year_router import router as academic_year_router
+from .academic_period_router import router as academic_period_router
 from .user_router import router as user_router
 from .class_router import router as class_router
 

--- a/backend/routers/academic_period_router.py
+++ b/backend/routers/academic_period_router.py
@@ -1,0 +1,45 @@
+# backend/routers/academic_period_router.py
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from core.db import get_db
+from schemas.academic_period import AcademicPeriodCreate, AcademicPeriodRead
+from repositories.academic_period_repository import AcademicPeriodRepository
+
+router = APIRouter(prefix="/academic-periods", tags=["academic_periods"])
+
+
+@router.post("/", response_model=AcademicPeriodRead)
+def create_academic_period(period: AcademicPeriodCreate, db: Session = Depends(get_db)):
+    repo = AcademicPeriodRepository(db)
+    return repo.create(period)
+
+
+@router.get("/{period_id}", response_model=AcademicPeriodRead)
+def read_academic_period(period_id: int, db: Session = Depends(get_db)):
+    repo = AcademicPeriodRepository(db)
+    db_period = repo.get(period_id)
+    if not db_period:
+        raise HTTPException(status_code=404, detail="Academic period not found")
+    return db_period
+
+
+@router.get("/", response_model=list[AcademicPeriodRead])
+def read_academic_periods(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    repo = AcademicPeriodRepository(db)
+    return repo.get_all(skip, limit)
+
+
+@router.put("/{period_id}", response_model=AcademicPeriodRead)
+def update_academic_period(period_id: int, updates: AcademicPeriodCreate, db: Session = Depends(get_db)):
+    repo = AcademicPeriodRepository(db)
+    if not repo.get(period_id):
+        raise HTTPException(status_code=404, detail="Academic period not found")
+    return repo.update(period_id, updates.dict())
+
+
+@router.delete("/{period_id}")
+def delete_academic_period(period_id: int, db: Session = Depends(get_db)):
+    repo = AcademicPeriodRepository(db)
+    repo.delete(period_id)
+    return {"ok": True}

--- a/backend/schemas/academic_period.py
+++ b/backend/schemas/academic_period.py
@@ -1,0 +1,26 @@
+# backend/schemas/academic_period.py
+from __future__ import annotations
+
+from datetime import date
+from pydantic import BaseModel
+
+from models.grade import TermTypeEnum
+
+
+class AcademicPeriodBase(BaseModel):
+    academic_year_id: int
+    term_type: TermTypeEnum
+    term_index: int
+    start_date: date
+    end_date: date
+
+
+class AcademicPeriodCreate(AcademicPeriodBase):
+    pass
+
+
+class AcademicPeriodRead(AcademicPeriodBase):
+    id: int
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- add AcademicPeriod schemas
- implement AcademicPeriodRepository
- create AcademicPeriod router with CRUD endpoints
- register router in FastAPI app

## Testing
- `pytest -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_686776be83d4833396ec1c67080ec39e