### PR TITLE
Use academic periods for term index

### DIFF
--- a/pydantic_settings.py
+++ b/pydantic_settings.py
@@ -1,0 +1,2 @@
+from pydantic import BaseSettings
+__all__ = ["BaseSettings"]


### PR DESCRIPTION
## Summary
- look up academic periods when setting grade term index
- add regression test for period lookup
- provide fallback `pydantic_settings` shim for tests

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_68677db91af48333b10799478de6db55