### PR TITLE
Handle old grade removal on import

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,5 +1,8 @@
 # backend/core/config.py
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:  # fallback for environments without pydantic-settings
+    from pydantic import BaseSettings
 from pydantic import Field
 
 


### PR DESCRIPTION
## Summary
- purge regular grades before importing new ones for a class & period
- fallback to `pydantic.BaseSettings` when `pydantic_settings` is unavailable
- test that old regular grades are removed during import

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_686782e9db088333bd7dfb93404c4453