### PR TITLE
Fix deletion of regular grades without joins

### DIFF
--- a/app/importer/service.py
+++ b/app/importer/service.py
@@ -124,10 +124,14 @@ class ImportService:
         if self.dry_run:
             return
         for class_id, year_id, term_type, term_index in keys:
+            event_ids = (
+                self.db.query(LessonEvent.id)
+                .filter(LessonEvent.class_id == class_id)
+                .subquery()
+            )
             (
                 self.db.query(Grade)
-                .join(LessonEvent)
-                .filter(LessonEvent.class_id == class_id)
+                .filter(Grade.lesson_event_id.in_(event_ids))
                 .filter(Grade.academic_year_id == year_id)
                 .filter(Grade.term_type == term_type)
                 .filter(Grade.term_index == term_index)


### PR DESCRIPTION
## Summary
- fix `_delete_old_regular_grades` to remove joins before calling `.delete`
- added subquery by lesson_event ids

## Testing
- `pytest tests/test_import_service.py::test_remove_old_regular_grades -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_68678694cea8833394fa02cfdd7af280