### PR TITLE
Improve progress report parsing

### DIFF
--- a/app/importer/constants.py
+++ b/app/importer/constants.py
@@ -6,8 +6,19 @@ STATUS_CHAR_MAP = {
 }
 
 
+import re
+
+
 def split_cell(value: str) -> list[str]:
-    return [part.strip() for part in str(value).split("/") if part and part.strip()]
+    """Return list of parts from a cell value.
+
+    The original implementation only split on ``/`` which meant values like
+    ``"О 2"`` were parsed as a single token. We now split on both ``/`` and
+    whitespace so that mixed values are handled correctly.
+    """
+
+    parts = re.split(r"[\s/]+", str(value))
+    return [part.strip() for part in parts if part and part.strip()]
 
 
 from dataclasses import dataclass, field

--- a/tests/test_split_cell.py
+++ b/tests/test_split_cell.py
@@ -18,3 +18,11 @@ def test_split_cell_empty():
 
 def test_split_cell_duplicates():
     assert split_cell("5/5/Н") == ["5", "5", "Н"]
+
+
+def test_split_cell_space_separator():
+    assert split_cell("О 2") == ["О", "2"]
+
+
+def test_split_cell_multiple_spaces():
+    assert split_cell("4  3") == ["4", "3"]


### PR DESCRIPTION
## Summary
- allow cell values to be split on spaces as well as `/`
- preserve both marks when several grades appear in one cell
- add tests for new parser behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b64ac6fa483339b6e4394cdfb7d2c