### PR TITLE
Fix student class update on import

### DIFF
--- a/backend/services/entity_service.py
+++ b/backend/services/entity_service.py
@@ -72,4 +72,10 @@ def resolve_or_create_student(
         )
         db.add(student)
         db.flush([student])
+    else:
+        # update class info if student moved to a different class
+        if student.class_id != class_id:
+            student.class_id = class_id
+            student.class_name = class_name
+            db.flush([student])
     return student.id


### PR DESCRIPTION
## Summary
- update `resolve_or_create_student` so students move to a different class if needed
- add regression test for importing a student with a new class

## Testing
- `pytest tests/test_import_service.py::test_student_class_update -q` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa267eb08333bdf94ea5d623f9e8