### PR TITLE
Secure class teacher router

### DIFF
--- a/backend/routers/class_teacher_router.py
+++ b/backend/routers/class_teacher_router.py
@@ -1,11 +1,17 @@
 # backend/routers/class_teacher_router.py
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+
 from core.db import get_db
 from schemas.class_teacher import ClassTeacherCreate, ClassTeacherRead
 from repositories.class_teacher_repository import ClassTeacherRepository
+from utils.dependencies import administrator_required
 
-router = APIRouter(prefix="/class-teachers", tags=["class_teachers"])
+router = APIRouter(
+    prefix="/class-teachers",
+    tags=["class_teachers"],
+    dependencies=[Depends(administrator_required)],
+)
 
 
 @router.post("/", response_model=ClassTeacherRead)

--- a/tests/test_class_teacher_router.py
+++ b/tests/test_class_teacher_router.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("SECRET_KEY", "x")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_NAME", "db")
+os.environ.setdefault("DB_USER", "user")
+os.environ.setdefault("DB_PASSWORD", "pass")
+
+from backend.routers.class_teacher_router import router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def test_assign_requires_authentication():
+    payload = {
+        "class_id": 1,
+        "teacher_id": 1,
+        "academic_year_id": 1,
+        "role": "regular",
+    }
+    resp = client.post("/class-teachers/", json=payload)
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- restrict class teacher endpoints to administrators
- add tests verifying auth requirement for class teacher routes

## Testing
- `pytest tests/test_split_cell.py tests/test_class_teacher_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e19abf1348333b940ee044d90abb5