### PR TITLE
Fix Pydantic BaseSettings import

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,5 +1,8 @@
 # backend/core/config.py
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ModuleNotFoundError:  # fallback for Pydantic v1
+    from pydantic import BaseSettings
 from pydantic import Field
 
 

--- a/pydantic_settings.py
+++ b/pydantic_settings.py
@@ -1,2 +1,0 @@
-from pydantic import BaseSettings
-__all__ = ["BaseSettings"]


### PR DESCRIPTION
## Summary
- remove custom `pydantic_settings.py` module
- allow `backend/core/config.py` to work with either Pydantic v1 or v2

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_686e27ff36808333918cb71631b11d37