### PR TITLE
Remove stale administrator import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,6 @@ from models import (
     grade,
     schedule,
     attendance,
-    administrator,
     user,
 )  # noqa
 


### PR DESCRIPTION
## Summary
- clean up `backend/main.py` import list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686e29cd740483339ff94237ab78e732