### PR TITLE
Fix dashboard bootstrap layout

### DIFF
--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -36,10 +36,12 @@ function App() {
   return (
     <>
       <Navbar onLogout={logout} />
-      <div className="d-flex" style={{ marginTop: '56px' }}>
+      <div className="d-flex">
         <Sidebar />
-        <main className="flex-grow-1 p-4">
-          {!token ? <LoginPane onLogin={login} /> : <Dashboard token={token} />}
+        <main className="flex-grow-1">
+          <div className="container-fluid py-4">
+            {!token ? <LoginPane onLogin={login} /> : <Dashboard token={token} />}
+          </div>
         </main>
       </div>
     </>

--- a/frontend-react/src/components/Dashboard.jsx
+++ b/frontend-react/src/components/Dashboard.jsx
@@ -61,33 +61,33 @@ function Dashboard({ token }) {
       </ul>
       <div className="tab-content">
         <div className="tab-pane fade show active" id="crPane" role="tabpanel">
-          <div className="row g-4 mb-4" id="kpiCards">
-            <div className="col-6 col-lg-3">
-              <div className="card shadow-sm border-0">
+          <div className="row row-cols-2 row-cols-lg-4 g-4 mb-4" id="kpiCards">
+            <div className="col">
+              <div className="card h-100 shadow-sm border-0">
                 <div className="card-body">
                   <h6 className="card-title text-muted">Средний балл</h6>
                   <h3 className="fw-bold mb-0" id="avgGrade">{stats.avg}</h3>
                 </div>
               </div>
             </div>
-            <div className="col-6 col-lg-3">
-              <div className="card shadow-sm border-0">
+            <div className="col">
+              <div className="card h-100 shadow-sm border-0">
                 <div className="card-body">
                   <h6 className="card-title text-muted">Отличники</h6>
                   <h3 className="fw-bold mb-0" id="excellentCount">{stats.excellent}</h3>
                 </div>
               </div>
             </div>
-            <div className="col-6 col-lg-3">
-              <div className="card shadow-sm border-0">
+            <div className="col">
+              <div className="card h-100 shadow-sm border-0">
                 <div className="card-body">
                   <h6 className="card-title text-muted">Неуспевающие</h6>
                   <h3 className="fw-bold mb-0 text-danger" id="failingCount">{stats.failing}</h3>
                 </div>
               </div>
             </div>
-            <div className="col-6 col-lg-3">
-              <div className="card shadow-sm border-0">
+            <div className="col">
+              <div className="card h-100 shadow-sm border-0">
                 <div className="card-body">
                   <h6 className="card-title text-muted">Пропуски (%)</h6>
                   <h3 className="fw-bold mb-0" id="absencePercent">–</h3>

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -28,6 +28,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  padding-top: 56px;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- remove inline margin from main layout
- add `padding-top` in global CSS
- update KPI grid classes

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e0e4e308333852752d7c51fb28c