### PR TITLE
Add filters for class and quarter

### DIFF
--- a/frontend-react/src/components/Dashboard.jsx
+++ b/frontend-react/src/components/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
@@ -23,6 +23,18 @@ function calcStats(grades) {
 
 function Dashboard({ token }) {
   const [stats, setStats] = useState({ avg: '–', excellent: '–', failing: '–' })
+  const [grades, setGrades] = useState([])
+  const [students, setStudents] = useState([])
+  const [selectedClass, setSelectedClass] = useState('all')
+  const [selectedQuarter, setSelectedQuarter] = useState('all')
+
+  const classOptions = useMemo(() => {
+    const uniq = {}
+    students.forEach(s => {
+      uniq[s.class_id] = s.class_name
+    })
+    return Object.entries(uniq).map(([id, name]) => ({ id, name }))
+  }, [students])
 
   useEffect(() => {
     async function fetchGrades() {
@@ -32,16 +44,46 @@ function Dashboard({ token }) {
       if (!res.ok) throw new Error('Failed to fetch grades')
       return await res.json()
     }
+
+    async function fetchStudents() {
+      const res = await fetch(`${API_URL}/students`, {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (!res.ok) throw new Error('Failed to fetch students')
+      return await res.json()
+    }
+
     async function update() {
       try {
-        const grades = await fetchGrades()
-        setStats(calcStats(grades))
+        const [g, s] = await Promise.all([fetchGrades(), fetchStudents()])
+        setGrades(g)
+        setStudents(s)
       } catch (e) {
         console.error(e)
       }
     }
+
     update()
   }, [token])
+
+  useEffect(() => {
+    if (!grades.length) return
+    const studentMap = {}
+    students.forEach(s => {
+      studentMap[s.id] = s
+    })
+    const filtered = grades.filter(g => {
+      if (selectedQuarter !== 'all') {
+        if (g.term_type !== 'quarter' || String(g.term_index) !== selectedQuarter) return false
+      }
+      if (selectedClass !== 'all') {
+        const st = studentMap[g.student_id]
+        if (!st || String(st.class_id) !== selectedClass) return false
+      }
+      return true
+    })
+    setStats(calcStats(filtered))
+  }, [grades, students, selectedClass, selectedQuarter])
 
   return (
     <div id="contentPane">
@@ -61,6 +103,25 @@ function Dashboard({ token }) {
       </ul>
       <div className="tab-content">
         <div className="tab-pane fade show active" id="crPane" role="tabpanel">
+          <div className="row g-3 mb-3">
+            <div className="col-auto">
+              <select className="form-select" value={selectedClass} onChange={e => setSelectedClass(e.target.value)}>
+                <option value="all">Все классы</option>
+                {classOptions.map(o => (
+                  <option key={o.id} value={o.id}>{o.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="col-auto">
+              <select className="form-select" value={selectedQuarter} onChange={e => setSelectedQuarter(e.target.value)}>
+                <option value="all">Весь год</option>
+                <option value="1">1 четверть</option>
+                <option value="2">2 четверть</option>
+                <option value="3">3 четверть</option>
+                <option value="4">4 четверть</option>
+              </select>
+            </div>
+          </div>
           <div className="row row-cols-2 row-cols-lg-4 g-4 mb-4" id="kpiCards">
             <div className="col">
               <div className="card h-100 shadow-sm border-0">


### PR DESCRIPTION
## Summary
- allow choosing class and quarter on the dashboard
- filter KPI stats based on selected parameters

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686f852b6b3c8333a698d8ebc86d4eaf