### PR TITLE
Allow reading classes without admin privileges

### DIFF
--- a/backend/routers/class_router.py
+++ b/backend/routers/class_router.py
@@ -7,10 +7,10 @@ from core.db import get_db
 from schemas.class_ import ClassCreate, ClassRead
 from repositories.class_repository import ClassRepository
 
-router = APIRouter(prefix="/classes", tags=["classes"], dependencies=[Depends(administrator_required)])
+router = APIRouter(prefix="/classes", tags=["classes"])
 
 
-@router.post("/", response_model=ClassRead)
+@router.post("/", response_model=ClassRead, dependencies=[Depends(administrator_required)])
 def create_class(school_class: ClassCreate, db: Session = Depends(get_db)):
     repo = ClassRepository(db)
     return repo.create(school_class)
@@ -37,7 +37,7 @@ def read_classes(
     return repo.get_all(skip, limit, school_id=school_id, academic_year_id=academic_year_id)
 
 
-@router.put("/{class_id}", response_model=ClassRead)
+@router.put("/{class_id}", response_model=ClassRead, dependencies=[Depends(administrator_required)])
 def update_class(class_id: int, updates: ClassCreate, db: Session = Depends(get_db)):
     repo = ClassRepository(db)
     if not repo.get(class_id):
@@ -45,7 +45,7 @@ def update_class(class_id: int, updates: ClassCreate, db: Session = Depends(get_
     return repo.update(class_id, updates.dict())
 
 
-@router.delete("/{class_id}")
+@router.delete("/{class_id}", dependencies=[Depends(administrator_required)])
 def delete_class(class_id: int, db: Session = Depends(get_db)):
     repo = ClassRepository(db)
     repo.delete(class_id)


### PR DESCRIPTION
## Summary
- remove admin restriction for fetching classes
- keep admin check on class modification routes

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_686f9eee5df883338600f1f1fe83058c