### PR TITLE
Implement user addition scenario

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_full_name_and_teacher_user_fk.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_full_name_and_teacher_user_fk.py
@@ -1,0 +1,29 @@
+"""add full_name to users and teacher.user_id
+
+Revision ID: a1b2c3d4e5f6
+Revises: f9f3a08e243c
+Create Date: 2025-09-01 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'f9f3a08e243c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('full_name', sa.String(length=50), nullable=True))
+    op.add_column('teachers', sa.Column('user_id', sa.Integer(), nullable=True))
+    op.create_unique_constraint('uq_teacher_user', 'teachers', ['user_id'])
+    op.create_foreign_key(None, 'teachers', 'users', ['user_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, 'teachers', type_='foreignkey')
+    op.drop_constraint('uq_teacher_user', 'teachers', type_='unique')
+    op.drop_column('teachers', 'user_id')
+    op.drop_column('users', 'full_name')

--- a/backend/models/teacher.py
+++ b/backend/models/teacher.py
@@ -11,6 +11,7 @@ class Teacher(Base):
     full_name = Column(String(50), nullable=False)
     contact_info = Column(String(100), nullable=True)
     school_id = Column(Integer, ForeignKey('schools.id', ondelete='CASCADE'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, unique=True)
     is_active = Column(Boolean, nullable=False, server_default='true')
 
     # Отношения
@@ -18,6 +19,7 @@ class Teacher(Base):
     grades = relationship('Grade', back_populates='teacher', cascade='all, delete-orphan')
     schedules = relationship('Schedule', back_populates='teacher', cascade='all, delete-orphan')
     school = relationship('School', back_populates='teachers')
+    user = relationship('User', back_populates='teacher')
     teacher_subjects = relationship(
         'TeacherSubject',
         back_populates='teacher',

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -17,7 +17,9 @@ class User(Base):
     username = Column(String(50), unique=True, index=True, nullable=False)
     password_hash = Column(String(255), nullable=False)
     role = Column(Enum(RoleEnum), nullable=False)
+    full_name = Column(String(50), nullable=True)
     school_id = Column(Integer, ForeignKey('schools.id', ondelete='CASCADE'), nullable=True)
 
     school = relationship('School', back_populates='users')
+    teacher = relationship('Teacher', back_populates='user', uselist=False)
 

--- a/backend/repositories/user_repository.py
+++ b/backend/repositories/user_repository.py
@@ -18,6 +18,7 @@ class UserRepository:
             role=user_in.role,
             password_hash=password_hash,
             school_id=user_in.school_id,
+            full_name=user_in.full_name,
         )
         self.db.add(user)
         self.db.commit()

--- a/backend/routers/user_router.py
+++ b/backend/routers/user_router.py
@@ -2,10 +2,13 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from core.db import get_db
-from schemas.user import UserCreate, UserRead
+from schemas.user import UserCreate, UserRead, AdminCreate, TeacherUserCreate
+from schemas.teacher import TeacherCreate
 from repositories.user_repository import UserRepository
+from repositories.teacher_repository import TeacherRepository
 from utils.utils import hash_password
 from utils.dependencies import admin_or_superuser_required
+from models.user import RoleEnum
 
 router = APIRouter(prefix="/users", tags=["users"], dependencies=[Depends(admin_or_superuser_required)])
 
@@ -16,6 +19,54 @@ def create_user(user_in: UserCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Username already registered")
     hashed = hash_password(user_in.password)
     return repo.create(user_in, hashed)
+
+
+@router.post("/administrators", response_model=UserRead)
+def create_administrator(admin: AdminCreate, db: Session = Depends(get_db)):
+    repo = UserRepository(db)
+    if repo.get_by_username(admin.username):
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = hash_password(admin.password)
+    user_in = UserCreate(
+        username=admin.username,
+        password=admin.password,
+        role=RoleEnum.administrator,
+        school_id=admin.school_id,
+        full_name=admin.full_name,
+    )
+    return repo.create(user_in, hashed)
+
+
+@router.post("/teachers", response_model=UserRead)
+def create_teacher_user(data: TeacherUserCreate, db: Session = Depends(get_db)):
+    user_repo = UserRepository(db)
+    teacher_repo = TeacherRepository(db)
+    if user_repo.get_by_username(data.username):
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = hash_password(data.password)
+    user_in = UserCreate(
+        username=data.username,
+        password=data.password,
+        role=RoleEnum.teacher,
+        school_id=data.school_id,
+        full_name=data.teacher_full_name if data.mode == "new" else None,
+    )
+    user = user_repo.create(user_in, hashed)
+    if data.mode == "existing":
+        teacher = teacher_repo.get(data.teacher_id)
+        if not teacher:
+            raise HTTPException(status_code=404, detail="Teacher not found")
+        teacher.user_id = user.id
+        db.commit()
+    else:
+        teacher = TeacherCreate(
+            full_name=data.teacher_full_name or data.username,
+            contact_info=data.contact_info,
+            school_id=data.school_id,
+            user_id=user.id,
+        )
+        teacher_repo.create(teacher)
+    return user
 
 @router.get("/{user_id}", response_model=UserRead)
 def read_user(user_id: int, db: Session = Depends(get_db)):

--- a/backend/schemas/teacher.py
+++ b/backend/schemas/teacher.py
@@ -6,6 +6,7 @@ class TeacherBase(BaseModel):
     full_name: str
     contact_info: Optional[str] = None
     school_id: int  # Новое поле
+    user_id: Optional[int] = None
 
 class TeacherCreate(TeacherBase):
     pass

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -5,6 +5,7 @@ class UserBase(BaseModel):
     username: str
     role: RoleEnum
     school_id: int | None = None
+    full_name: str | None = None
 
 class UserCreate(UserBase):
     password: str
@@ -18,4 +19,21 @@ class UserRead(UserBase):
 class Token(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+
+class AdminCreate(BaseModel):
+    username: str
+    password: str
+    full_name: str
+    school_id: int
+
+
+class TeacherUserCreate(BaseModel):
+    username: str
+    password: str
+    school_id: int
+    mode: str  # "existing" or "new"
+    teacher_id: int | None = None
+    teacher_full_name: str | None = None
+    contact_info: str | None = None
 


### PR DESCRIPTION
## Summary
- add `full_name` column to `users` table and relation between teachers and users
- provide migrations for new fields
- extend schemas to include new data
- support creating administrators and teacher accounts via `/users/administrators` and `/users/teachers`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError/RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_6870a9014b3c83338ea2b99e5bf5be9c